### PR TITLE
Fix quoting in client/update_dns f-string

### DIFF
--- a/client/update_dns.py
+++ b/client/update_dns.py
@@ -22,7 +22,7 @@ def main():
     if ip:
         payload['ip'] = ip
 
-    resp = requests.post(f'{backend.rstrip('/')}/update', json=payload)
+    resp = requests.post(f"{backend.rstrip('/')}/update", json=payload)
     print(resp.status_code, resp.text)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- escape inner quotes for f-string in `client/update_dns.py`

## Testing
- `python -m py_compile client/update_dns.py`

------
https://chatgpt.com/codex/tasks/task_b_68540917bdd48321b55780f59e50534b