### PR TITLE
Fix Dockerfile copy paths

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY backend/requirements.txt ./
+COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-COPY backend/ ./
+COPY . ./
 EXPOSE 80
 ENV LISTEN_PORT=80
 CMD ["python", "app.py"]


### PR DESCRIPTION
## Summary
- update backend Dockerfile to reference files relative to build context

## Testing
- `docker build -t test-image -f backend/Dockerfile ./backend` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68540ab02e6c8321b923446c0500bb08