### PR TITLE
Remove redundant env-file flag in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ component comes with its own `Dockerfile` inside the respective
 Start the backend service:
 
 ```bash
-docker compose -f backend/docker-compose.yml --env-file .secrets up
+docker compose -f backend/docker-compose.yml up
 ```
+The compose file already includes an `env_file` entry pointing to `.secrets`, so
+there is no need to pass it explicitly on the command line.
 
 Run the client (typically on another host) and point it to your backend:
 


### PR DESCRIPTION
## Summary
- update README to remove `--env-file` flag
- clarify that compose already uses the `.secrets` file

## Testing
- `python -m py_compile backend/app.py client/update_dns.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68540b6f1d148321ad35a982eaf2c685