### PR TITLE
Use published images in compose

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,17 +19,17 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push backend
-        uses: docker/build-push-action@v4
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile
-          push: true
-          tags: ${{ secrets.IMAGE_NAME }}:backend
-      - name: Build and push client
-        uses: docker/build-push-action@v4
-        with:
-          context: ./client
-          file: ./client/Dockerfile
-          push: true
-          tags: ${{ secrets.IMAGE_NAME }}:client
+        - name: Build and push backend
+          uses: docker/build-push-action@v4
+          with:
+            context: ./backend
+            file: ./backend/Dockerfile
+            push: true
+            tags: nmbit/hetzner-dyndns-backend:latest
+        - name: Build and push client
+          uses: docker/build-push-action@v4
+          with:
+            context: ./client
+            file: ./client/Dockerfile
+            push: true
+            tags: nmbit/hetzner-dyndns-client:latest

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ command‑line arguments.
 
 Separate compose files are provided for the backend and the client. Each
 component comes with its own `Dockerfile` inside the respective
-`backend` and `client` directories.
+`backend` and `client` directories. By default the compose files pull the
+public images `nmbit/hetzner-dyndns-backend` and `nmbit/hetzner-dyndns-client`.
+Uncomment the `build` sections if you want to build the images locally.
 
 Start the backend service:
 
@@ -63,8 +65,8 @@ starting the backend.
 
 ## GitHub Actions
 
-A workflow builds Docker images for the backend and the client and
-pushes them to Docker Hub.  Provide `DOCKERHUB_USERNAME`,
-`DOCKERHUB_TOKEN` and `IMAGE_NAME` (e.g. `<username>/<repo>`) as
-repository secrets to control where the images are published.
+A workflow builds the Docker images from the local Dockerfiles and
+pushes them to Docker Hub. Provide `DOCKERHUB_USERNAME` and
+`DOCKERHUB_TOKEN` as repository secrets so the workflow can publish the
+`nmbit/hetzner-dyndns-backend` and `nmbit/hetzner-dyndns-client` images.
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,9 +1,10 @@
 version: '3'
 services:
   backend:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: nmbit/hetzner-dyndns-backend
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
     ports:
       - "8000:80"
     env_file:

--- a/client/docker-compose.yml
+++ b/client/docker-compose.yml
@@ -1,7 +1,8 @@
 version: '3'
 services:
   client:
-    build: .
+    image: nmbit/hetzner-dyndns-client
+    # build: .
     environment:
       - BACKEND_URL=http://backend:80  # replace with the URL of your backend
       - FQDN=example.yourdomain.tld


### PR DESCRIPTION
## Summary
- default docker-compose files pull published images `nmbit/hetzner-dyndns-backend` and `nmbit/hetzner-dyndns-client`
- keep local build instructions in compose files as comments
- update the GitHub Actions workflow to publish to the same images
- document new behaviour in README

## Testing
- `python -m py_compile backend/app.py client/update_dns.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685410ed2e68832186ecbc63bc0ad371