### PR TITLE
Update workflow for separate image repositories

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,17 +19,17 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        - name: Build and push backend
-          uses: docker/build-push-action@v4
-          with:
-            context: ./backend
-            file: ./backend/Dockerfile
-            push: true
-            tags: nmbit/hetzner-dyndns-backend:latest
-        - name: Build and push client
-          uses: docker/build-push-action@v4
-          with:
-            context: ./client
-            file: ./client/Dockerfile
-            push: true
-            tags: nmbit/hetzner-dyndns-client:latest
+      - name: Build and push backend
+        uses: docker/build-push-action@v4
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: ${{ secrets.IMAGE_NAME_BACKEND }}:latest
+      - name: Build and push client
+        uses: docker/build-push-action@v4
+        with:
+          context: ./client
+          file: ./client/Dockerfile
+          push: true
+          tags: ${{ secrets.IMAGE_NAME_CLIENT }}:latest

--- a/README.md
+++ b/README.md
@@ -66,7 +66,14 @@ starting the backend.
 ## GitHub Actions
 
 A workflow builds the Docker images from the local Dockerfiles and
-pushes them to Docker Hub. Provide `DOCKERHUB_USERNAME` and
-`DOCKERHUB_TOKEN` as repository secrets so the workflow can publish the
-`nmbit/hetzner-dyndns-backend` and `nmbit/hetzner-dyndns-client` images.
+pushes them to Docker Hub. Provide these repository secrets so the
+workflow can publish your images:
+
+- `DOCKERHUB_USERNAME`
+- `DOCKERHUB_TOKEN`
+- `IMAGE_NAME_BACKEND`
+- `IMAGE_NAME_CLIENT`
+
+The backend image is pushed to `IMAGE_NAME_BACKEND` and the client
+image to `IMAGE_NAME_CLIENT`.
 


### PR DESCRIPTION
## Summary
- support separate repo names for backend and client
- document new GitHub secrets for custom Docker repos

## Testing
- `python -m compileall -q backend client`

------
https://chatgpt.com/codex/tasks/task_b_685409b10480832185282c0e623dfcfd