### PR TITLE
Add configurable debug logging to backend

### DIFF
--- a/.secrets.example
+++ b/.secrets.example
@@ -1,3 +1,7 @@
 HETZNER_TOKEN=your-hetzner-token
 NTFY_URL=https://ntfy.example.com
 NTFY_TOPIC=HetznerDynDNSIssue
+DEBUG_LOGGING=0
+#LOG_FILE=app.log
+#LOG_MAX_BYTES=1048576
+#LOG_BACKUP_COUNT=3

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The container reads the following variables which should be provided via a
 - `HETZNER_TOKEN` – API token for the Hetzner DNS API
 - `NTFY_URL` – Base URL of your NTFY instance
 - `NTFY_TOPIC` – Topic name used for notifications
+- `DEBUG_LOGGING` – set to `1` to enable verbose debug logs (default `0`)
+- `LOG_FILE` – path to the rotating log file (default `app.log`)
+- `LOG_MAX_BYTES` – maximum size of the log file before rotation (default 1048576)
+- `LOG_BACKUP_COUNT` – number of rotated log files to keep (default 3)
 
 ## Client
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,6 @@
 import os
+import logging
+from logging.handlers import RotatingFileHandler
 from flask import Flask, request, jsonify, abort
 import requests
 
@@ -7,6 +9,21 @@ app = Flask(__name__)
 HETZNER_TOKEN = os.environ.get("HETZNER_TOKEN")
 NTFY_URL = os.environ.get("NTFY_URL")
 NTFY_TOPIC = os.environ.get("NTFY_TOPIC")
+
+# Logging configuration
+DEBUG_LOGGING = os.environ.get("DEBUG_LOGGING", "0").lower() in ("1", "true", "yes")
+LOG_FILE = os.environ.get("LOG_FILE", "app.log")
+LOG_MAX_BYTES = int(os.environ.get("LOG_MAX_BYTES", str(1 * 1024 * 1024)))
+LOG_BACKUP_COUNT = int(os.environ.get("LOG_BACKUP_COUNT", "3"))
+
+log_level = logging.DEBUG if DEBUG_LOGGING else logging.INFO
+handler = RotatingFileHandler(LOG_FILE, maxBytes=LOG_MAX_BYTES,
+                              backupCount=LOG_BACKUP_COUNT)
+logging.basicConfig(level=log_level,
+                    format="%(asctime)s %(levelname)s %(message)s",
+                    handlers=[handler, logging.StreamHandler()])
+
+app.logger.setLevel(log_level)
 
 
 def send_ntfy(title: str, message: str) -> None:
@@ -26,8 +43,11 @@ def update():
         abort(500, 'Backend not configured')
 
     data = request.get_json(silent=True) or {}
+    if DEBUG_LOGGING:
+        app.logger.debug("Request JSON: %s", data)
     url = data.get('fqdn') or data.get('url')
     if not url:
+        app.logger.error("Request from %s missing fqdn", request.remote_addr)
         send_ntfy('Param Error', 'Missing FQDN')
         return jsonify({'error': 'Missing FQDN'}), 400
 
@@ -37,6 +57,7 @@ def update():
 
     domain_parts = url.split('.')
     if len(domain_parts) < 2:
+        app.logger.error("Request from %s invalid fqdn: %s", request.remote_addr, url)
         send_ntfy('Param Error', 'Invalid FQDN')
         return jsonify({'error': 'Invalid FQDN'}), 400
 
@@ -46,6 +67,8 @@ def update():
     zones_resp = requests.get('https://dns.hetzner.com/api/v1/zones',
                               headers={'Auth-API-Token': HETZNER_TOKEN})
     if zones_resp.status_code != 200:
+        app.logger.error("Zone fetch failed for %s from %s: %s", url,
+                         request.remote_addr, zones_resp.text)
         send_ntfy('Zone Fetch Failed', zones_resp.text)
         return jsonify({'error': 'Failed to fetch zones'}), 500
 
@@ -56,6 +79,8 @@ def update():
             break
 
     if not zone_id:
+        app.logger.error("Zone not found for %s from %s", domain,
+                         request.remote_addr)
         send_ntfy('Zone Not Found', f'No matching zone for {domain}')
         return jsonify({'error': 'Zone not found'}), 404
 
@@ -63,6 +88,8 @@ def update():
         f'https://dns.hetzner.com/api/v1/records?zone_id={zone_id}',
         headers={'Auth-API-Token': HETZNER_TOKEN})
     if records_resp.status_code != 200:
+        app.logger.error("Records fetch failed for %s from %s: %s", url,
+                         request.remote_addr, records_resp.text)
         send_ntfy('Records Fetch Failed', records_resp.text)
         return jsonify({'error': 'Failed to fetch records'}), 500
 
@@ -96,9 +123,13 @@ def update():
         action = 'Created'
 
     if resp.ok:
+        app.logger.info("%s request from %s for %s -> %s", action.lower(),
+                        request.remote_addr, url, ip)
         send_ntfy('DynDNS Success', f'{action} A record for {url} -> {ip}')
         return jsonify({'status': action.lower(), 'ip': ip}), 200
     else:
+        app.logger.error("Failed to %s record for %s from %s: %s", action.lower(),
+                         url, request.remote_addr, resp.text)
         send_ntfy(f'{action} Failed', resp.text)
         return jsonify({'error': 'API failure', 'detail': resp.text}), 500
 


### PR DESCRIPTION
## Summary
- add optional debug logging and rotating file handler
- log all update requests with client IP and status
- document new environment variables and defaults
- extend `.secrets.example` with logging configuration

## Testing
- `python -m py_compile backend/app.py`
- `python -m py_compile client/update_dns.py`


------
https://chatgpt.com/codex/tasks/task_b_68541ff14334832194800bfbdba8ee0a