### PR TITLE
Add client update loop with interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ python update_dns.py <backend_url> <fqdn> [ip]
 ```
 
 Environment variables `BACKEND_URL`, `FQDN` and `IP` can also be used instead of
-command‑line arguments.
+command‑line arguments. Setting `INTERVAL` to a number of seconds will repeat the
+update in that interval (e.g. `INTERVAL=3600` for hourly updates).
 
 ## Docker Compose
 

--- a/client/docker-compose.yml
+++ b/client/docker-compose.yml
@@ -7,3 +7,5 @@ services:
       - BACKEND_URL=http://backend:80  # replace with the URL of your backend
       - FQDN=example.yourdomain.tld
       # - IP=1.2.3.4  # optional static IP variant
+      # update interval in seconds
+      - INTERVAL=3600

--- a/client/update_dns.py
+++ b/client/update_dns.py
@@ -1,11 +1,13 @@
 import os
 import sys
+import time
 import requests
 
 def main():
     backend = os.environ.get('BACKEND_URL')
     fqdn = os.environ.get('FQDN')
     ip = os.environ.get('IP')
+    interval = int(os.environ.get('INTERVAL', '0'))
 
     if len(sys.argv) > 1:
         backend = sys.argv[1]
@@ -22,8 +24,12 @@ def main():
     if ip:
         payload['ip'] = ip
 
-    resp = requests.post(f"{backend.rstrip('/')}/update", json=payload)
-    print(resp.status_code, resp.text)
+    while True:
+        resp = requests.post(f"{backend.rstrip('/')}/update", json=payload)
+        print(resp.status_code, resp.text)
+        if interval <= 0:
+            break
+        time.sleep(interval)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- support repeated updates in `client/update_dns.py`
- document new `INTERVAL` variable
- show `INTERVAL` usage in compose file

## Testing
- `python -m py_compile client/update_dns.py backend/app.py`

------
https://chatgpt.com/codex/tasks/task_b_685442f540088321b328007f9c957805