### PR TITLE
Build Docker images on releases

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,8 +1,8 @@
 name: Build and Push Docker Images
 
 on:
-  push:
-    branches: [ main ]
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -25,11 +25,15 @@ jobs:
           context: ./backend
           file: ./backend/Dockerfile
           push: true
-          tags: ${{ secrets.IMAGE_NAME_BACKEND }}:latest
+          tags: |
+            ${{ secrets.IMAGE_NAME_BACKEND }}:${{ github.event.release.tag_name }}
+            ${{ secrets.IMAGE_NAME_BACKEND }}:latest
       - name: Build and push client
         uses: docker/build-push-action@v4
         with:
           context: ./client
           file: ./client/Dockerfile
           push: true
-          tags: ${{ secrets.IMAGE_NAME_CLIENT }}:latest
+          tags: |
+            ${{ secrets.IMAGE_NAME_CLIENT }}:${{ github.event.release.tag_name }}
+            ${{ secrets.IMAGE_NAME_CLIENT }}:latest

--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ starting the backend.
 
 ## GitHub Actions
 
-A workflow builds the Docker images from the local Dockerfiles and
-pushes them to Docker Hub. Provide these repository secrets so the
-workflow can publish your images:
+A workflow builds the Docker images from the local Dockerfiles when a
+GitHub release is published. The images are tagged with the release
+version as well as `latest` and then pushed to Docker Hub. Provide these
+repository secrets so the workflow can publish your images:
 
 - `DOCKERHUB_USERNAME`
 - `DOCKERHUB_TOKEN`


### PR DESCRIPTION
## Summary
- update the GitHub workflow to publish images only on release events
- document release-based image publishing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6854466a82888321869eca2707fa9bea