### PR TITLE
Add certifi for certificate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ python update_dns.py <backend_url> <fqdn> [ip]
 Environment variables `BACKEND_URL`, `FQDN` and `IP` can also be used instead of
 command‑line arguments.
 
+The client uses the [`certifi`](https://pypi.org/project/certifi/) package for
+certificate verification.  Set `CA_BUNDLE` to override the bundle path or set
+`VERIFY_SSL=0` to disable verification entirely.
+
 ## Docker Compose
 
 Separate compose files are provided for the backend and the client. Each

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.31.0
+certifi>=2024.2.2

--- a/client/update_dns.py
+++ b/client/update_dns.py
@@ -1,6 +1,22 @@
 import os
 import sys
 import requests
+try:
+    import certifi
+except ImportError:  # certifi might not be installed in some environments
+    certifi = None
+
+def get_verify_option():
+    """Return the verify parameter for requests based on environment vars."""
+    ca_bundle = os.environ.get("CA_BUNDLE")
+    if ca_bundle:
+        return ca_bundle
+    verify_env = os.environ.get("VERIFY_SSL")
+    if verify_env is not None and verify_env.lower() in ("0", "false", "no"):
+        return False
+    if certifi is not None:
+        return certifi.where()
+    return True
 
 def main():
     backend = os.environ.get('BACKEND_URL')
@@ -22,7 +38,8 @@ def main():
     if ip:
         payload['ip'] = ip
 
-    resp = requests.post(f"{backend.rstrip('/')}/update", json=payload)
+    verify = get_verify_option()
+    resp = requests.post(f"{backend.rstrip('/')}/update", json=payload, verify=verify)
     print(resp.status_code, resp.text)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- use `certifi.where()` as the default CA bundle in the client
- document certifi usage
- add certifi to client requirements

## Testing
- `python -m py_compile client/update_dns.py`
- `python client/update_dns.py http://example.com example.com` *(returns 403 from example.com)*

------
https://chatgpt.com/codex/tasks/task_b_68544212d0c88321b6d018f4ce3e918d