### PR TITLE
Use X-Real-Ip header for updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ endpoint accepts JSON payloads of the form:
 { "fqdn": "host.example.com", "ip": "1.2.3.4" }
 ```
 
-`ip` is optional. If omitted, the source IP of the HTTP request is used. The
+`ip` is optional. If omitted, the backend uses the `X-Real-Ip` header if
+present, then `X-Forwarded-For`, and finally the source IP of the HTTP request.
+The
 service notifies a configured NTFY topic about success or failure.
 Install the requirements with `pip install -r backend/requirements.txt` before running the service directly.
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -48,6 +48,8 @@ def update():
         app.logger.debug("Request JSON: %s", data)
         app.logger.debug("Request headers: %s", dict(request.headers))
         app.logger.debug("Remote address: %s", request.remote_addr)
+        if 'X-Real-Ip' in request.headers:
+            app.logger.debug("X-Real-Ip: %s", request.headers.get('X-Real-Ip'))
         if 'X-Forwarded-For' in request.headers:
             app.logger.debug("X-Forwarded-For: %s", request.headers.get('X-Forwarded-For'))
     url = data.get('fqdn') or data.get('url')
@@ -57,6 +59,10 @@ def update():
         return jsonify({'error': 'Missing FQDN'}), 400
 
     ip = data.get('ip')
+    if not ip:
+        ip = request.headers.get('X-Real-Ip')
+    if not ip and 'X-Forwarded-For' in request.headers:
+        ip = request.headers.get('X-Forwarded-For').split(',')[0].strip()
     if not ip:
         ip = request.remote_addr
 


### PR DESCRIPTION
## Summary
- log the `X-Real-Ip` header when debug logging is enabled
- check the `X-Real-Ip` or `X-Forwarded-For` headers before falling back to `remote_addr`
- document IP header usage in README

## Testing
- `python -m py_compile backend/app.py client/update_dns.py`


------
https://chatgpt.com/codex/tasks/task_b_685449413ef08321b2d93f19ec8db7b0