### PR TITLE
Add optional ntfy authentication support

### DIFF
--- a/.secrets.example
+++ b/.secrets.example
@@ -1,6 +1,8 @@
 HETZNER_TOKEN=your-hetzner-token
 NTFY_URL=https://ntfy.example.com
 NTFY_TOPIC=HetznerDynDNSIssue
+#NTFY_USERNAME=user
+#NTFY_PASSWORD=pass
 DEBUG_LOGGING=0
 #LOG_FILE=app.log
 #LOG_MAX_BYTES=1048576

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The container reads the following variables which should be provided via a
 - `HETZNER_TOKEN` – API token for the Hetzner DNS API
 - `NTFY_URL` – Base URL of your NTFY instance
 - `NTFY_TOPIC` – Topic name used for notifications
+- `NTFY_USERNAME` / `NTFY_PASSWORD` – credentials for basic auth with NTFY (optional)
 - `DEBUG_LOGGING` – set to `1` to enable verbose debug logs (default `0`)
 - `LOG_FILE` – path to the rotating log file (default `app.log`)
 - `LOG_MAX_BYTES` – maximum size of the log file before rotation (default 1048576)

--- a/backend/.secrets.example
+++ b/backend/.secrets.example
@@ -1,6 +1,8 @@
 HETZNER_TOKEN=your-hetzner-token
 NTFY_URL=https://ntfy.example.com
 NTFY_TOPIC=HetznerDynDNSIssue
+#NTFY_USERNAME=user
+#NTFY_PASSWORD=pass
 DEBUG_LOGGING=0
 #LOG_FILE=app.log
 #LOG_MAX_BYTES=1048576

--- a/backend/app.py
+++ b/backend/app.py
@@ -9,6 +9,8 @@ app = Flask(__name__)
 HETZNER_TOKEN = os.environ.get("HETZNER_TOKEN")
 NTFY_URL = os.environ.get("NTFY_URL")
 NTFY_TOPIC = os.environ.get("NTFY_TOPIC")
+NTFY_USERNAME = os.environ.get("NTFY_USERNAME")
+NTFY_PASSWORD = os.environ.get("NTFY_PASSWORD")
 
 # Logging configuration
 DEBUG_LOGGING = os.environ.get("DEBUG_LOGGING", "0").lower() in ("1", "true", "yes")
@@ -31,11 +33,15 @@ def send_ntfy(title: str, message: str) -> None:
     if not NTFY_URL:
         return
     headers = {"Title": title} if title else {}
+    auth = None
+    if NTFY_USERNAME and NTFY_PASSWORD:
+        auth = (NTFY_USERNAME, NTFY_PASSWORD)
     try:
         requests.post(
             f"{NTFY_URL}/{NTFY_TOPIC}" if NTFY_TOPIC else NTFY_URL,
             headers=headers,
             data=message,
+            auth=auth,
             timeout=10,
         )
     except Exception:

--- a/tests/test_backend_update.py
+++ b/tests/test_backend_update.py
@@ -16,14 +16,14 @@ def test_update_creates_record(monkeypatch):
     monkeypatch.setattr(backend_app, "HETZNER_TOKEN", "token")
     monkeypatch.setattr(backend_app, "send_ntfy", lambda *a, **k: None)
 
-    def mock_get(url, headers=None):
+    def mock_get(url, headers=None, **kwargs):
         if url.endswith("/zones"):
             return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
         elif url.startswith("https://dns.hetzner.com/api/v1/records"):
             return DummyResp({"records": []})
         raise AssertionError("unexpected GET " + url)
 
-    def mock_post(url, headers=None, json=None):
+    def mock_post(url, headers=None, json=None, **kwargs):
         assert url.endswith("/records")
         return DummyResp({"record": {"id": "r1"}})
 

--- a/tests/test_send_ntfy.py
+++ b/tests/test_send_ntfy.py
@@ -1,0 +1,33 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from backend import app as backend_app
+
+
+def test_send_ntfy_with_auth(monkeypatch):
+    called = {}
+    def mock_post(url, headers=None, data=None, auth=None, timeout=None):
+        called['auth'] = auth
+        return type('R', (), {})()
+    monkeypatch.setattr(backend_app.requests, 'post', mock_post)
+    monkeypatch.setattr(backend_app, 'NTFY_URL', 'http://ntfy')
+    monkeypatch.setattr(backend_app, 'NTFY_TOPIC', None)
+    monkeypatch.setattr(backend_app, 'NTFY_USERNAME', 'user')
+    monkeypatch.setattr(backend_app, 'NTFY_PASSWORD', 'pass')
+
+    backend_app.send_ntfy('t', 'm')
+    assert called['auth'] == ('user', 'pass')
+
+
+def test_send_ntfy_without_auth(monkeypatch):
+    called = {}
+    def mock_post(url, headers=None, data=None, auth=None, timeout=None):
+        called['auth'] = auth
+        return type('R', (), {})()
+    monkeypatch.setattr(backend_app.requests, 'post', mock_post)
+    monkeypatch.setattr(backend_app, 'NTFY_URL', 'http://ntfy')
+    monkeypatch.setattr(backend_app, 'NTFY_TOPIC', None)
+    monkeypatch.setattr(backend_app, 'NTFY_USERNAME', None)
+    monkeypatch.setattr(backend_app, 'NTFY_PASSWORD', None)
+
+    backend_app.send_ntfy('t', 'm')
+    assert called['auth'] is None


### PR DESCRIPTION
## Summary
- allow backend to authenticate to ntfy via `NTFY_USERNAME`/`NTFY_PASSWORD`
- document the new variables
- show example credentials in `.secrets.example`
- update backend tests for timeout parameter
- test ntfy auth logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68544bc1146c832198e176c2026d1667