### PR TITLE
Handle invalid interval env

### DIFF
--- a/client/update_dns.py
+++ b/client/update_dns.py
@@ -23,7 +23,11 @@ def main():
     backend = os.environ.get('BACKEND_URL')
     fqdn = os.environ.get('FQDN')
     ip = os.environ.get('IP')
-    interval = int(os.environ.get('INTERVAL', '0'))
+    try:
+        interval = int(os.environ.get('INTERVAL', '0'))
+    except (TypeError, ValueError):
+        print("Invalid INTERVAL, defaulting to 0")
+        interval = 0
 
     if len(sys.argv) > 1:
         backend = sys.argv[1]


### PR DESCRIPTION
## Summary
- validate INTERVAL environment variable in update_dns client
- test INTERVAL parsing behaviour

## Testing
- `python -m py_compile client/update_dns.py`
- `python -m py_compile tests/test_client_update_dns.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854545e766483219b6ed7e90384a88e