### PR TITLE
Improve client error handling

### DIFF
--- a/client/update_dns.py
+++ b/client/update_dns.py
@@ -43,12 +43,21 @@ def main():
 
     while True:
         verify = get_verify_option()
-        resp = requests.post(
-            f"{backend.rstrip('/')}/update",
-            json=payload,
-            verify=verify,
-            timeout=10,
-        )
+        try:
+            resp = requests.post(
+                f"{backend.rstrip('/')}/update",
+                json=payload,
+                verify=verify,
+                timeout=10,
+            )
+        except requests.exceptions.RequestException as exc:
+            print(exc)
+            sys.exit(1)
+
+        if not (200 <= resp.status_code < 300):
+            print(resp.status_code, resp.text)
+            sys.exit(1)
+
         if interval <= 0:
             break
         time.sleep(interval)

--- a/tests/test_client_update_dns.py
+++ b/tests/test_client_update_dns.py
@@ -1,5 +1,6 @@
 import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from client import update_dns
+import pytest
 
 
 def test_get_verify_option_ca_bundle(monkeypatch):
@@ -30,3 +31,34 @@ def test_get_verify_option_default(monkeypatch):
     monkeypatch.delenv("VERIFY_SSL", raising=False)
     monkeypatch.setattr(update_dns, "certifi", None, raising=False)
     assert update_dns.get_verify_option() is True
+
+
+def test_main_request_exception(monkeypatch):
+    monkeypatch.setenv("BACKEND_URL", "http://backend")
+    monkeypatch.setenv("FQDN", "host.example.com")
+    monkeypatch.setenv("INTERVAL", "0")
+
+    def mock_post(*args, **kwargs):
+        raise update_dns.requests.exceptions.RequestException("boom")
+
+    monkeypatch.setattr(update_dns.requests, "post", mock_post)
+
+    with pytest.raises(SystemExit) as excinfo:
+        update_dns.main()
+    assert excinfo.value.code != 0
+
+
+def test_main_non_2xx(monkeypatch):
+    monkeypatch.setenv("BACKEND_URL", "http://backend")
+    monkeypatch.setenv("FQDN", "host.example.com")
+    monkeypatch.setenv("INTERVAL", "0")
+
+    class DummyResp:
+        status_code = 500
+        text = "err"
+
+    monkeypatch.setattr(update_dns.requests, "post", lambda *a, **k: DummyResp())
+
+    with pytest.raises(SystemExit) as excinfo:
+        update_dns.main()
+    assert excinfo.value.code != 0

--- a/tests/test_client_update_dns.py
+++ b/tests/test_client_update_dns.py
@@ -1,6 +1,7 @@
 import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from client import update_dns
 import pytest
+import requests
 
 
 def test_get_verify_option_ca_bundle(monkeypatch):
@@ -39,9 +40,9 @@ def test_main_request_exception(monkeypatch):
     monkeypatch.setenv("INTERVAL", "0")
 
     def mock_post(*args, **kwargs):
-        raise update_dns.requests.exceptions.RequestException("boom")
+        raise requests.exceptions.RequestException("boom")
 
-    monkeypatch.setattr(update_dns.requests, "post", mock_post)
+    monkeypatch.setattr(requests, "post", mock_post)
 
     with pytest.raises(SystemExit) as excinfo:
         update_dns.main()
@@ -57,7 +58,7 @@ def test_main_non_2xx(monkeypatch):
         status_code = 500
         text = "err"
 
-    monkeypatch.setattr(update_dns.requests, "post", lambda *a, **k: DummyResp())
+    monkeypatch.setattr(requests, "post", lambda *a, **k: DummyResp())
 
     with pytest.raises(SystemExit) as excinfo:
         update_dns.main()


### PR DESCRIPTION
## Summary
- exit on request errors or non-2xx responses
- test error handling in update_dns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68545463ae008321a426b33d29547aac