### PR TITLE
Improve error handling in DNS update client

### DIFF
--- a/client/update_dns.py
+++ b/client/update_dns.py
@@ -47,12 +47,21 @@ def main():
 
     while True:
         verify = get_verify_option()
-        resp = requests.post(
-            f"{backend.rstrip('/')}/update",
-            json=payload,
-            verify=verify,
-            timeout=10,
-        )
+        try:
+            resp = requests.post(
+                f"{backend.rstrip('/')}/update",
+                json=payload,
+                verify=verify,
+                timeout=10,
+            )
+        except requests.exceptions.RequestException as exc:
+            print(exc)
+            sys.exit(1)
+
+        if not (200 <= resp.status_code < 300):
+            print(resp.status_code, resp.text)
+            sys.exit(1)
+
         if interval <= 0:
             break
         time.sleep(interval)


### PR DESCRIPTION
## Summary
- exit with status 1 when update requests fail
- print HTTP status code and body when response is not 2xx
- unit tests for request failures

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r backend/requirements.txt -r client/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68545e0794488321be343f64b0434795