### PR TITLE
Fix debug mode mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The container reads the following variables which should be provided via a
 - `NTFY_URL` – Base URL of your NTFY instance
 - `NTFY_TOPIC` – Topic name used for notifications
 - `NTFY_USERNAME` / `NTFY_PASSWORD` – credentials for basic auth with NTFY (optional)
-- `DEBUG_LOGGING` – set to `1` to enable verbose debug logs (default `0`)
+- `DEBUG_LOGGING` – set to `1` to enable verbose debug logs and Flask debug mode (default `0`)
 - `LOG_FILE` – path to the rotating log file (default `app.log`)
 - `LOG_MAX_BYTES` – maximum size of the log file before rotation (default 1048576)
 - `LOG_BACKUP_COUNT` – number of rotated log files to keep (default 3)

--- a/backend/app.py
+++ b/backend/app.py
@@ -170,4 +170,4 @@ def update():
 
 if __name__ == '__main__':
     port = int(os.environ.get('LISTEN_PORT', '80'))
-    app.run(host='0.0.0.0', port=port)
+    app.run(host='0.0.0.0', port=port, debug=DEBUG_LOGGING)


### PR DESCRIPTION
## Summary
- enable Flask debug mode if `DEBUG_LOGGING` is set
- document that this flag also enables Flask debug mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685462d1f8b88321b27783aad13e2136