### PR TITLE
Unify container names in Compose files

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   backend:
     image: nmbit/hetzner-dyndns-backend
+    container_name: dyndns
     # build:
     #   context: .
     #   dockerfile: Dockerfile

--- a/client/docker-compose.yml
+++ b/client/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   client:
     image: nmbit/hetzner-dyndns-client
+    container_name: dyndns
     # build: .
     environment:
       - BACKEND_URL=http://backend:80  # replace with the URL of your backend


### PR DESCRIPTION
## Summary
- specify consistent `container_name: dyndns` for backend and client

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r backend/requirements.txt -r client/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68546303d9c48321a575ea9d290642fe