### PR TITLE
Add backend update tests

### DIFF
--- a/tests/test_backend_update.py
+++ b/tests/test_backend_update.py
@@ -34,3 +34,51 @@ def test_update_creates_record(monkeypatch):
     resp = client.post("/update", json={"fqdn": "host.example.com", "ip": "1.2.3.4"})
     assert resp.status_code == 200
     assert resp.get_json() == {"status": "created", "ip": "1.2.3.4"}
+
+
+def test_update_updates_record(monkeypatch):
+    monkeypatch.setattr(backend_app, "HETZNER_TOKEN", "token")
+    monkeypatch.setattr(backend_app, "send_ntfy", lambda *a, **k: None)
+
+    def mock_get(url, headers=None, **kwargs):
+        if url.endswith("/zones"):
+            return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
+        elif url.startswith("https://dns.hetzner.com/api/v1/records"):
+            return DummyResp({"records": [{"id": "r1", "name": "host", "type": "A"}]})
+        raise AssertionError("unexpected GET " + url)
+
+    def mock_put(url, headers=None, json=None, **kwargs):
+        assert url.endswith("/records/r1")
+        return DummyResp({"record": {"id": "r1"}})
+
+    monkeypatch.setattr(backend_app.requests, "get", mock_get)
+    monkeypatch.setattr(backend_app.requests, "put", mock_put)
+
+    client = backend_app.app.test_client()
+    resp = client.post("/update", json={"fqdn": "host.example.com", "ip": "1.2.3.4"})
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "updated", "ip": "1.2.3.4"}
+
+
+def test_update_api_failure(monkeypatch):
+    monkeypatch.setattr(backend_app, "HETZNER_TOKEN", "token")
+    monkeypatch.setattr(backend_app, "send_ntfy", lambda *a, **k: None)
+
+    def mock_get(url, headers=None, **kwargs):
+        if url.endswith("/zones"):
+            return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
+        elif url.startswith("https://dns.hetzner.com/api/v1/records"):
+            return DummyResp({"records": []})
+        raise AssertionError("unexpected GET " + url)
+
+    def mock_post(url, headers=None, json=None, **kwargs):
+        assert url.endswith("/records")
+        return DummyResp({"error": "boom"}, status_code=500)
+
+    monkeypatch.setattr(backend_app.requests, "get", mock_get)
+    monkeypatch.setattr(backend_app.requests, "post", mock_post)
+
+    client = backend_app.app.test_client()
+    resp = client.post("/update", json={"fqdn": "host.example.com", "ip": "1.2.3.4"})
+    assert resp.status_code == 500
+    assert resp.get_json() == {"error": "API failure", "detail": "{\"error\": \"boom\"}"}


### PR DESCRIPTION
## Summary
- add tests for updating an existing record
- add test for failed Hetzner API call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68546449b9888321b647d90c3112084f