### PR TITLE
Document backend API key setup

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -10,3 +10,6 @@ services:
       - "8000:80"
     env_file:
       - ./.secrets
+    volumes:
+      # persists the generated API key for sharing with the client
+      - ./pre-shared-key:/pre-shared-key

--- a/client/docker-compose.yml
+++ b/client/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     environment:
       - BACKEND_URL=http://backend:80  # replace with the URL of your backend
       - FQDN=example.yourdomain.tld
+      # value from backend's pre-shared-key/key.txt
+      - API_KEY=change-me
       # - IP=1.2.3.4  # optional static IP variant
       # update interval in seconds
       - INTERVAL=3600


### PR DESCRIPTION
## Summary
- document how to mount `pre-shared-key` and copy the generated key
- add API key examples for backend and client
- update environment variable lists
- show API key usage in curl example
- mount `pre-shared-key` in backend compose
- add `API_KEY` placeholder in client compose

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -q -r backend/requirements.txt -r client/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685472bf56b8832196f8103bd18388ee