### PR TITLE
Add API key authentication

### DIFF
--- a/.secrets.example
+++ b/.secrets.example
@@ -1,6 +1,8 @@
 HETZNER_TOKEN=your-hetzner-token
 NTFY_URL=https://ntfy.example.com
 NTFY_TOPIC=HetznerDynDNSIssue
+# Optional API key for /update requests
+API_KEY=
 #NTFY_USERNAME=user
 #NTFY_PASSWORD=pass
 DEBUG_LOGGING=0

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The container reads the following variables which should be provided via a
 `.secrets` file or other means:
 
 - `HETZNER_TOKEN` – API token for the Hetzner DNS API
+- `API_KEY` – shared secret required in the `X-API-Key` header
 - `NTFY_URL` – Base URL of your NTFY instance
 - `NTFY_TOPIC` – Topic name used for notifications
 - `NTFY_USERNAME` / `NTFY_PASSWORD` – credentials for basic auth with NTFY (optional)

--- a/client/update_dns.py
+++ b/client/update_dns.py
@@ -23,6 +23,7 @@ def main():
     backend = os.environ.get('BACKEND_URL')
     fqdn = os.environ.get('FQDN')
     ip = os.environ.get('IP')
+    api_key = os.environ.get('API_KEY')
     try:
         interval = int(os.environ.get('INTERVAL', '0'))
     except (TypeError, ValueError):
@@ -52,10 +53,12 @@ def main():
         if ip:
             msg += f" ip={ip}"
         print(msg, flush=True)
+        headers = {"X-API-Key": api_key} if api_key else None
         try:
             resp = requests.post(
                 f"{backend.rstrip('/')}/update",
                 json=payload,
+                headers=headers,
                 verify=verify,
                 timeout=10,
             )

--- a/tests/test_backend_update.py
+++ b/tests/test_backend_update.py
@@ -14,6 +14,7 @@ class DummyResp:
 
 def test_update_creates_record(monkeypatch):
     monkeypatch.setattr(backend_app, "HETZNER_TOKEN", "token")
+    monkeypatch.setattr(backend_app, "API_KEY", "secret")
     monkeypatch.setattr(backend_app, "send_ntfy", lambda *a, **k: None)
 
     def mock_get(url, headers=None, **kwargs):
@@ -31,13 +32,14 @@ def test_update_creates_record(monkeypatch):
     monkeypatch.setattr(backend_app.requests, "post", mock_post)
 
     client = backend_app.app.test_client()
-    resp = client.post("/update", json={"fqdn": "host.example.com", "ip": "1.2.3.4"})
+    resp = client.post("/update", json={"fqdn": "host.example.com", "ip": "1.2.3.4"}, headers={"X-API-Key": "secret"})
     assert resp.status_code == 200
     assert resp.get_json() == {"status": "created", "ip": "1.2.3.4"}
 
 
 def test_update_request_exception(monkeypatch):
     monkeypatch.setattr(backend_app, "HETZNER_TOKEN", "token")
+    monkeypatch.setattr(backend_app, "API_KEY", "secret")
     called = {}
     monkeypatch.setattr(backend_app, "send_ntfy", lambda *a, **k: called.setdefault('ntfy', True))
 
@@ -47,7 +49,7 @@ def test_update_request_exception(monkeypatch):
     monkeypatch.setattr(backend_app.requests, "get", mock_get)
 
     client = backend_app.app.test_client()
-    resp = client.post("/update", json={"fqdn": "host.example.com"})
+    resp = client.post("/update", json={"fqdn": "host.example.com"}, headers={"X-API-Key": "secret"})
     assert resp.status_code == 500
     data = resp.get_json()
     assert "error" in data
@@ -56,6 +58,7 @@ def test_update_request_exception(monkeypatch):
 
 def test_update_updates_record(monkeypatch):
     monkeypatch.setattr(backend_app, "HETZNER_TOKEN", "token")
+    monkeypatch.setattr(backend_app, "API_KEY", "secret")
     monkeypatch.setattr(backend_app, "send_ntfy", lambda *a, **k: None)
 
     def mock_get(url, headers=None, **kwargs):
@@ -73,13 +76,14 @@ def test_update_updates_record(monkeypatch):
     monkeypatch.setattr(backend_app.requests, "put", mock_put)
 
     client = backend_app.app.test_client()
-    resp = client.post("/update", json={"fqdn": "host.example.com", "ip": "1.2.3.4"})
+    resp = client.post("/update", json={"fqdn": "host.example.com", "ip": "1.2.3.4"}, headers={"X-API-Key": "secret"})
     assert resp.status_code == 200
     assert resp.get_json() == {"status": "updated", "ip": "1.2.3.4"}
 
 
 def test_update_api_failure(monkeypatch):
     monkeypatch.setattr(backend_app, "HETZNER_TOKEN", "token")
+    monkeypatch.setattr(backend_app, "API_KEY", "secret")
     called = {}
     monkeypatch.setattr(backend_app, "send_ntfy", lambda *a, **k: called.setdefault('ntfy', True))
 
@@ -98,7 +102,7 @@ def test_update_api_failure(monkeypatch):
     monkeypatch.setattr(backend_app.requests, "post", mock_post)
 
     client = backend_app.app.test_client()
-    resp = client.post("/update", json={"fqdn": "host.example.com", "ip": "1.2.3.4"})
+    resp = client.post("/update", json={"fqdn": "host.example.com", "ip": "1.2.3.4"}, headers={"X-API-Key": "secret"})
     assert resp.status_code == 500
     data = resp.get_json()
     assert data.get("error") == "API failure"


### PR DESCRIPTION
## Summary
- support optional API key auth in backend and client
- send `X-API-Key` header from client when `API_KEY` is set
- update example secrets and docs
- extend tests for API key handling

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r backend/requirements.txt -r client/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685472c2f1b48321b4e3097d7620f781