### PR TITLE
Use gunicorn in backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir gunicorn
 COPY . ./
 EXPOSE 80
 ENV LISTEN_PORT=80
-CMD ["python", "app.py"]
+CMD ["gunicorn", "-b", "0.0.0.0:80", "app:app"]


### PR DESCRIPTION
## Summary
- install gunicorn in `backend/Dockerfile`
- run backend via gunicorn instead of Flask dev server

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68547db2716483218d01100d0c480b71