### PR TITLE
Secure API key file

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -30,6 +30,7 @@ def _load_api_key() -> str:
         try:
             with open(API_KEY_FILE, "w") as f:
                 f.write(key)
+            os.chmod(API_KEY_FILE, 0o600)
         except Exception as exc:  # pragma: no cover - shouldn't happen
             print(f"Failed to write API key: {exc}")
     return key


### PR DESCRIPTION
## Summary
- call `os.chmod` after writing `/pre-shared-key` so the file is not world-readable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68547db4b28883219f25161f66097bec