### PR TITLE
Handle missing API_KEY in client

### DIFF
--- a/client/update_dns.py
+++ b/client/update_dns.py
@@ -37,6 +37,10 @@ def main():
     if len(sys.argv) > 3:
         ip = sys.argv[3]
 
+    if not api_key:
+        print('API_KEY not set')
+        sys.exit(1)
+
     if not backend or not fqdn:
         print('Usage: update_dns.py <backend_url> <fqdn> [ip]')
         sys.exit(1)

--- a/tests/test_client_update_dns.py
+++ b/tests/test_client_update_dns.py
@@ -38,6 +38,7 @@ def test_invalid_interval_defaults_to_zero(monkeypatch, capsys):
     monkeypatch.setenv("BACKEND_URL", "http://b")
     monkeypatch.setenv("FQDN", "host.example.com")
     monkeypatch.setenv("INTERVAL", "bad")
+    monkeypatch.setenv("API_KEY", "k")
     monkeypatch.delenv("IP", raising=False)
 
     called = {}
@@ -62,6 +63,7 @@ def test_invalid_interval_defaults_to_zero(monkeypatch, capsys):
 def test_update_dns_request_exception(monkeypatch, capsys):
     monkeypatch.setenv("BACKEND_URL", "http://b")
     monkeypatch.setenv("FQDN", "host.example.com")
+    monkeypatch.setenv("API_KEY", "k")
     monkeypatch.delenv("IP", raising=False)
 
     def mock_post(*args, **kwargs):
@@ -80,6 +82,7 @@ def test_update_dns_request_exception(monkeypatch, capsys):
 def test_update_dns_non_2xx(monkeypatch, capsys):
     monkeypatch.setenv("BACKEND_URL", "http://b")
     monkeypatch.setenv("FQDN", "host.example.com")
+    monkeypatch.setenv("API_KEY", "k")
     monkeypatch.delenv("IP", raising=False)
 
     class DummyResp:
@@ -97,3 +100,16 @@ def test_update_dns_non_2xx(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "500" in out
     assert "fail" in out
+
+
+def test_missing_api_key(monkeypatch, capsys):
+    monkeypatch.setenv("BACKEND_URL", "http://b")
+    monkeypatch.setenv("FQDN", "host.example.com")
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.delenv("IP", raising=False)
+    monkeypatch.setattr(sys, "argv", ["update_dns.py"], raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        update_dns.main()
+    assert exc.value.code == 1
+    assert "API_KEY not set" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- exit with an error when `API_KEY` is unset in `update_dns.py`
- set `API_KEY` in tests that expect successful client execution
- add test case for missing API key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854836aa3dc83219f455e4aa6597f40