### PR TITLE
Fix test imports for flake8

### DIFF
--- a/tests/test_backend_update.py
+++ b/tests/test_backend_update.py
@@ -1,4 +1,7 @@
-import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from backend import app as backend_app
 import json
 

--- a/tests/test_client_update_dns.py
+++ b/tests/test_client_update_dns.py
@@ -1,4 +1,7 @@
-import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from client import update_dns
 import pytest
 import requests

--- a/tests/test_send_ntfy.py
+++ b/tests/test_send_ntfy.py
@@ -1,4 +1,6 @@
-import os, sys
+import os
+import sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from backend import app as backend_app
 


### PR DESCRIPTION
## Summary
- split multi-import lines in test modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6854888e67dc832195237469a23a528f