### PR TITLE
Add pre-commit with flake8 and pytest

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E401,E402,E302,E305,E303,E306,E702,E301

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.2.0
+    hooks:
+      - id: flake8
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -177,10 +177,16 @@ image to `IMAGE_NAME_CLIENT`.
 
 ## Development
 
-Install the development requirements and run the test suite with `pytest`:
+Install the development requirements and set up the pre-commit hook:
 
 ```bash
 pip install -r requirements-dev.txt
-pytest
+pre-commit install
+```
+
+Run the test suite with `pytest` or invoke all hooks using:
+
+```bash
+pre-commit run --all-files
 ```
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,3 @@
 pytest==8.3.5
+flake8==7.2.0
+pre-commit==4.2.0


### PR DESCRIPTION
## Summary
- add pre-commit configuration with flake8 and pytest hooks
- configure flake8 rules
- include pre-commit and flake8 in dev requirements
- document pre-commit usage in README

## Testing
- `pre-commit run --files backend/app.py client/update_dns.py tests/test_backend_update.py tests/test_client_update_dns.py tests/test_send_ntfy.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685488a857408321aa8938e14b2c5438