### PR TITLE
Fix flake8 E401 in tests

### DIFF
--- a/tests/test_backend_update.py
+++ b/tests/test_backend_update.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/tests/test_client_update_dns.py
+++ b/tests/test_client_update_dns.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/tests/test_send_ntfy.py
+++ b/tests/test_send_ntfy.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 
 sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))


### PR DESCRIPTION
## Summary
- split multiple imports on single line in tests

## Testing
- `flake8 tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68548a244258832198c1aa4a0cd5785c