### PR TITLE
Add package layout and simplify test imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+# Hetzner DynDNS package

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+# backend package

--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,0 +1,1 @@
+# client package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hetzner_dyndns"
+version = "0.0.0"
+readme = "README.md"
+requires-python = ">=3.8"
+
+[tool.setuptools.packages.find]
+where = ["."]
+exclude = ["tests*"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests package

--- a/tests/test_backend_update.py
+++ b/tests/test_backend_update.py
@@ -1,10 +1,4 @@
-import os
-import sys
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
-from backend import app as backend_app
+from hetzner_dyndns.backend import app as backend_app
 import json
 
 

--- a/tests/test_client_update_dns.py
+++ b/tests/test_client_update_dns.py
@@ -1,10 +1,5 @@
-import os
 import sys
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
-from client import update_dns
+from hetzner_dyndns.client import update_dns
 import pytest
 import requests
 

--- a/tests/test_send_ntfy.py
+++ b/tests/test_send_ntfy.py
@@ -1,10 +1,4 @@
-import os
-import sys
-
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
-from backend import app as backend_app
+from hetzner_dyndns.backend import app as backend_app
 
 
 def test_send_ntfy_with_auth(monkeypatch):


### PR DESCRIPTION
## Summary
- package the project via `pyproject.toml`
- add `__init__.py` files for backend, client and tests
- import modules via the package path in tests

## Testing
- `pip install -e .`
- `pytest tests/test_backend_update.py tests/test_client_update_dns.py tests/test_send_ntfy.py -q`
- `pre-commit run --files tests/test_backend_update.py tests/test_client_update_dns.py tests/test_send_ntfy.py backend/__init__.py client/__init__.py tests/__init__.py pyproject.toml`

------
https://chatgpt.com/codex/tasks/task_b_68548dff80bc8321817df2cf8be9a32c