### PR TITLE
Improve README for backend key file

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ The backend authenticates requests using a pre-shared key stored in
 not exist on the first start, the service creates it and writes a random
 token. Use this value for the client's `API_KEY` setting.
 
+When using Docker Compose, make sure the file exists before starting the
+container. Otherwise Docker will create a directory instead of a file for
+the volume which leads to an error similar to "not a directory". An empty
+file can be created with `touch backend/pre-shared-key`.
+
 ### Environment variables
 
 The container reads the following variables which should be provided via a


### PR DESCRIPTION
## Summary
- clarify that `backend/pre-shared-key` must exist before running docker-compose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854972ca21083218bcf48d1a46ea807