### PR TITLE
Add restart policy for compose services

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ docker compose -f backend/docker-compose.yml up  # on server side
 docker compose -f client/docker-compose.yml up  # on client side
 ```
 
+Both compose files use a `restart: unless-stopped` policy so the containers
+automatically start again after a Docker restart.
+
 Compose files live in [`backend/docker-compose.yml`](backend/docker-compose.yml)
 and [`client/docker-compose.yml`](client/docker-compose.yml).
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   backend:
     image: nmbit/hetzner-dyndns-backend
     container_name: dyndns
+    restart: unless-stopped
     # build:
     #   context: .
     #   dockerfile: Dockerfile

--- a/client/docker-compose.yml
+++ b/client/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   client:
     image: nmbit/hetzner-dyndns-client
     container_name: dyndns
+    restart: unless-stopped
     # build: .
     environment:
       - BACKEND_URL=http://backend:80  # replace with the URL of your backend


### PR DESCRIPTION
## Summary
- ensure both Docker Compose files use `restart: unless-stopped`
- document automatic restarts in Quickstart

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854a3632b9883219428944405cfbd74