### PR TITLE
Adjust ntfy notification logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ An optional `type` field may be provided with `A` or `AAAA` to explicitly select
 the record type. Without it the backend defaults to an IPv4 `A` record.
 Both IPv4 and IPv6 addresses are validated using Python's `ipaddress`
 module before being accepted. The service notifies a configured NTFY topic
-about success or failure.
+about failures, while success messages are only sent when debug logging is
+enabled.
 Install the requirements with `pip install -r backend/requirements.txt` before running the service directly.
 
 The backend authenticates requests using a pre-shared key stored in

--- a/tests/test_send_ntfy.py
+++ b/tests/test_send_ntfy.py
@@ -13,6 +13,7 @@ def test_send_ntfy_with_auth(monkeypatch):
     monkeypatch.setattr(backend_app, "NTFY_TOPIC", None)
     monkeypatch.setattr(backend_app, "NTFY_USERNAME", "user")
     monkeypatch.setattr(backend_app, "NTFY_PASSWORD", "pass")
+    monkeypatch.setattr(backend_app, "DEBUG_LOGGING", True)
 
     backend_app.send_ntfy("t", "m")
     assert called["auth"] == ("user", "pass")
@@ -30,6 +31,7 @@ def test_send_ntfy_without_auth(monkeypatch):
     monkeypatch.setattr(backend_app, "NTFY_TOPIC", None)
     monkeypatch.setattr(backend_app, "NTFY_USERNAME", None)
     monkeypatch.setattr(backend_app, "NTFY_PASSWORD", None)
+    monkeypatch.setattr(backend_app, "DEBUG_LOGGING", True)
 
     backend_app.send_ntfy("t", "m")
     assert called["auth"] is None


### PR DESCRIPTION
## Summary
- notify via ntfy about successes only when DEBUG_LOGGING is enabled
- always notify about errors
- document new behaviour in README
- update tests

## Testing
- `pre-commit run --files backend/app.py README.md tests/test_send_ntfy.py`

------
https://chatgpt.com/codex/tasks/task_b_68551cbcd7ac83218980b35d2ed18799