### PR TITLE
Switch Dockerfiles to alpine base

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.11-slim
+FROM python:3.11-alpine
 
 # create non-root user
-RUN adduser --disabled-password --gecos '' appuser
+RUN adduser -D -g '' appuser
 
 WORKDIR /app
 COPY requirements.txt ./

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,9 +1,7 @@
-FROM python:3.11-slim
+FROM python:3.11-alpine
 WORKDIR /client
 COPY requirements.txt ./
-RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates \
- && rm -rf /var/lib/apt/lists/* \
+RUN apk add --no-cache ca-certificates \
  && pip install --no-cache-dir -r requirements.txt
 COPY update_dns.py ./
 ENTRYPOINT ["python", "update_dns.py"]


### PR DESCRIPTION
## Summary
- use Python Alpine images for Docker builds
- adjust `adduser` for alpine
- install ca-certificates via `apk` on client image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68552f3e0c38832185aa5a5427ca685f