### PR TITLE
Clarify pre-shared key usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ The repository contains two parts:
    - `HETZNER_TOKEN` – your Hetzner DNS API token
    - `NTFY_URL` – base URL of your NTFY instance
    - `NTFY_TOPIC` – topic name for notifications
-2. List your hostnames in `REGISTERED_FQDNS` inside
-   `backend/.secrets` and create a writable `backend/pre-shared-key` file:
+2. List your hostnames in `REGISTERED_FQDNS` inside `backend/.secrets`.
+   Store the tokens for these hosts in a writable `backend/pre-shared-key` file
+   (one `fqdn key` pair per line). The backend compose file mounts this file at
+   `/pre-shared-key` and generates keys for any missing hosts automatically, so
+   no `PRE_SHARED_KEY` variable is required on the server:
 
    ```bash
    touch backend/pre-shared-key
@@ -85,10 +88,11 @@ cache lifetime is controlled by `REQUEST_CACHE_TTL`.
 
 The backend authenticates requests using per-host pre-shared keys stored in
 `./pre-shared-key` on the host and mounted into the container at
-`/pre-shared-key` (see `backend/docker-compose.yml`). The hostnames are
-configured via the `REGISTERED_FQDNS` environment variable. On first start
-the service generates a random key for each hostname and writes the mapping
-to the file. Use the matching key from this file for every client.
+`/pre-shared-key` (see `backend/docker-compose.yml`). There is no
+`PRE_SHARED_KEY` environment variable for the backend. Hostnames are
+configured via the `REGISTERED_FQDNS` variable. On first start the service
+generates a random key for each hostname and writes the mapping to the file.
+Use the matching key from this file for every client.
 
 When using Docker Compose, make sure the file exists and is writable by the
 container user. Otherwise Docker may create a directory instead of a file and

--- a/backend/.secrets.example
+++ b/backend/.secrets.example
@@ -7,7 +7,8 @@ DEBUG_LOGGING=0
 #LOG_FILE=
 #LOG_MAX_BYTES=1048576
 #LOG_BACKUP_COUNT=3
-# comma-separated list of allowed hostnames, keys generated on startup
+# comma-separated list of allowed hostnames
+# matching tokens are stored in ./pre-shared-key and generated on startup
 REGISTERED_FQDNS=host.example.com
 #BASIC_AUTH_USERNAME=
 #BASIC_AUTH_PASSWORD=

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -12,4 +12,4 @@ services:
     env_file:
       - ./.secrets
     volumes:
-      - ./pre-shared-key:/pre-shared-key
+      - ./pre-shared-key:/pre-shared-key  # token file generated on first start


### PR DESCRIPTION
## Summary
- clarify in README that pre-shared keys are stored in a file and not in `.secrets`
- document pre-shared-key file in `backend/.secrets.example`

## Testing
- `pre-commit run --files README.md backend/.secrets.example backend/docker-compose.yml` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_6855379d281c8321a8694985b2e059a9