### PR TITLE
Update backend to use LISTEN_PORT

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,4 +20,4 @@ ENV LISTEN_PORT=80
 # drop privileges
 USER appuser
 
-CMD ["gunicorn", "-b", "0.0.0.0:80", "app:app"]
+CMD ["sh", "-c", "gunicorn -b 0.0.0.0:${LISTEN_PORT:-80} app:app"]


### PR DESCRIPTION
## Summary
- support custom port in backend Dockerfile

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68554810393c83219aa270bbf1a710d7