### PR TITLE
Remove redundant Readme header

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ and [`client/docker-compose.yml`](client/docker-compose.yml).
 
 ---
 
-# Readme
-
 This project provides a lightweight REST API for updating Hetzner DNS A/AAAA records.
 It consists of a backend service that communicates with the Hetzner DNS API and
 an optional client that can be run on remote systems to trigger updates.


### PR DESCRIPTION
## Summary
- delete duplicate "Readme" header in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68554a0d72c483218d1b0e86922d9580