### PR TITLE
Fix client interval default to 60

### DIFF
--- a/client/docker-compose.yml
+++ b/client/docker-compose.yml
@@ -11,4 +11,4 @@ services:
       - PRE_SHARED_KEY=
       # - IP=1.2.3.4  # optional static IP variant
       # update interval in seconds
-      - INTERVAL=3600
+      - INTERVAL=60

--- a/client/update_dns.py
+++ b/client/update_dns.py
@@ -28,10 +28,10 @@ def main():
     fqdn = os.environ.get("FQDN")
     ip = os.environ.get("IP")
     try:
-        interval = int(os.environ.get("INTERVAL", "0"))
+        interval = int(os.environ.get("INTERVAL", "60"))
     except (TypeError, ValueError):
-        print("Invalid INTERVAL, defaulting to 0")
-        interval = 0
+        print("Invalid INTERVAL, defaulting to 60")
+        interval = 60
 
     if len(sys.argv) > 1:
         backend = sys.argv[1]

--- a/tests/test_client_update_dns.py
+++ b/tests/test_client_update_dns.py
@@ -36,7 +36,7 @@ def test_get_verify_option_default(monkeypatch):
     assert update_dns.get_verify_option() is True
 
 
-def test_invalid_interval_defaults_to_zero(monkeypatch, capsys):
+def test_invalid_interval_defaults_to_sixty(monkeypatch, capsys):
     monkeypatch.setenv("BACKEND_URL", "http://b")
     monkeypatch.setenv("FQDN", "host.example.com")
     monkeypatch.setenv("INTERVAL", "bad")
@@ -57,7 +57,13 @@ def test_invalid_interval_defaults_to_zero(monkeypatch, capsys):
     monkeypatch.setattr(update_dns, "get_verify_option", lambda: True)
     monkeypatch.setattr(sys, "argv", ["update_dns.py"], raising=False)
 
-    update_dns.main()
+    def fake_sleep(i):
+        raise StopIteration()
+
+    monkeypatch.setattr(update_dns.time, "sleep", fake_sleep)
+
+    with pytest.raises(StopIteration):
+        update_dns.main()
     assert called["url"] == "http://b/update"
     assert "Invalid INTERVAL" in capsys.readouterr().out
 
@@ -66,6 +72,7 @@ def test_update_dns_request_exception(monkeypatch, capsys):
     monkeypatch.setenv("BACKEND_URL", "http://b")
     monkeypatch.setenv("FQDN", "host.example.com")
     monkeypatch.setenv("PRE_SHARED_KEY", "k")
+    monkeypatch.setenv("INTERVAL", "0")
     monkeypatch.delenv("IP", raising=False)
 
     def mock_post(*args, **kwargs):
@@ -85,6 +92,7 @@ def test_update_dns_non_2xx(monkeypatch, capsys):
     monkeypatch.setenv("BACKEND_URL", "http://b")
     monkeypatch.setenv("FQDN", "host.example.com")
     monkeypatch.setenv("PRE_SHARED_KEY", "k")
+    monkeypatch.setenv("INTERVAL", "0")
     monkeypatch.delenv("IP", raising=False)
 
     class DummyResp:


### PR DESCRIPTION
## Summary
- set client INTERVAL env default to 60 seconds
- update example compose file
- adjust tests for new interval default

## Testing
- `pre-commit run --files client/update_dns.py client/docker-compose.yml tests/test_client_update_dns.py`
- `pytest -k '' -vv`

------
https://chatgpt.com/codex/tasks/task_b_68554b6742e483218c563caebd209743