### PR TITLE
Clamp interval to zero for client

### DIFF
--- a/client/update_dns.py
+++ b/client/update_dns.py
@@ -32,6 +32,7 @@ def main():
     except (TypeError, ValueError):
         print("Invalid INTERVAL, defaulting to 0")
         interval = 0
+    interval = max(0, interval)
 
     if len(sys.argv) > 1:
         backend = sys.argv[1]


### PR DESCRIPTION
## Summary
- clamp negative INTERVAL values to zero
- test that negative INTERVAL behaves like 0

## Testing
- `pre-commit run --files client/update_dns.py tests/test_client_update_dns.py`

------
https://chatgpt.com/codex/tasks/task_b_68554fd58fb08321bb3422ef63244280