### PR TITLE
Use specific Python image tags

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python:3.11.7-alpine
 
 # create non-root user
 RUN adduser -D -g '' appuser

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python:3.11.7-alpine
 WORKDIR /client
 COPY requirements.txt ./
 RUN apk add --no-cache ca-certificates \


### PR DESCRIPTION
## Summary
- pin Dockerfiles to `python:3.11.7-alpine`

## Testing
- `pre-commit run --files backend/Dockerfile client/Dockerfile`
- `docker build -t hetzner-backend-test backend` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685550038680832199a345041bf2ed79