### PR TITLE
Handle ntfy post errors

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -207,13 +207,16 @@ def send_ntfy(title: str, message: str, *, is_error: bool = False) -> None:
     if NTFY_USERNAME and NTFY_PASSWORD:
         auth = (NTFY_USERNAME, NTFY_PASSWORD)
     try:
-        requests.post(
+        resp = requests.post(
             f"{NTFY_URL}/{NTFY_TOPIC}" if NTFY_TOPIC else NTFY_URL,
             headers=headers,
             data=message,
             auth=auth,
             timeout=10,
         )
+        if not resp.ok:
+            log = app.logger.error if is_error else app.logger.warning
+            log("ntfy returned %s: %s", resp.status_code, resp.text)
     except requests.RequestException:
         app.logger.exception("Failed to send ntfy message")
 

--- a/tests/test_send_ntfy.py
+++ b/tests/test_send_ntfy.py
@@ -4,9 +4,14 @@ from hetzner_dyndns.backend import app as backend_app
 def test_send_ntfy_with_auth(monkeypatch):
     called = {}
 
+    class DummyResp:
+        status_code = 200
+        ok = True
+        text = ""
+
     def mock_post(url, headers=None, data=None, auth=None, timeout=None):
         called["auth"] = auth
-        return type("R", (), {})()
+        return DummyResp()
 
     monkeypatch.setattr(backend_app.requests, "post", mock_post)
     monkeypatch.setattr(backend_app, "NTFY_URL", "http://ntfy")
@@ -22,9 +27,14 @@ def test_send_ntfy_with_auth(monkeypatch):
 def test_send_ntfy_without_auth(monkeypatch):
     called = {}
 
+    class DummyResp:
+        status_code = 200
+        ok = True
+        text = ""
+
     def mock_post(url, headers=None, data=None, auth=None, timeout=None):
         called["auth"] = auth
-        return type("R", (), {})()
+        return DummyResp()
 
     monkeypatch.setattr(backend_app.requests, "post", mock_post)
     monkeypatch.setattr(backend_app, "NTFY_URL", "http://ntfy")
@@ -35,3 +45,39 @@ def test_send_ntfy_without_auth(monkeypatch):
 
     backend_app.send_ntfy("t", "m")
     assert called["auth"] is None
+
+
+def test_send_ntfy_logs_error(monkeypatch):
+    class DummyResp:
+        status_code = 500
+        ok = False
+        text = "fail"
+
+    monkeypatch.setattr(backend_app.requests, "post", lambda *a, **k: DummyResp())
+    monkeypatch.setattr(backend_app, "NTFY_URL", "http://ntfy")
+    monkeypatch.setattr(backend_app, "NTFY_TOPIC", None)
+    monkeypatch.setattr(backend_app, "DEBUG_LOGGING", True)
+
+    logs = []
+    monkeypatch.setattr(backend_app.app.logger, "error", lambda msg, *a: logs.append(msg % a))
+
+    backend_app.send_ntfy("t", "m", is_error=True)
+    assert "500" in logs[0]
+
+
+def test_send_ntfy_logs_warning(monkeypatch):
+    class DummyResp:
+        status_code = 500
+        ok = False
+        text = "fail"
+
+    monkeypatch.setattr(backend_app.requests, "post", lambda *a, **k: DummyResp())
+    monkeypatch.setattr(backend_app, "NTFY_URL", "http://ntfy")
+    monkeypatch.setattr(backend_app, "NTFY_TOPIC", None)
+    monkeypatch.setattr(backend_app, "DEBUG_LOGGING", True)
+
+    logs = []
+    monkeypatch.setattr(backend_app.app.logger, "warning", lambda msg, *a: logs.append(msg % a))
+
+    backend_app.send_ntfy("t", "m")
+    assert "500" in logs[0]


### PR DESCRIPTION
## Summary
- capture the `requests.post` result in `send_ntfy`
- log a warning or error when ntfy returns a non-2xx status
- test error logging for failed ntfy calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685550299a10832186c4c193a04d66a9