### PR TITLE
Ensure log directory exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ The container reads the following variables which should be provided via a
 - `REGISTERED_FQDNS` – comma-separated hostnames to manage
 - `NTFY_USERNAME` / `NTFY_PASSWORD` – credentials for basic auth with NTFY (optional)
 - `DEBUG_LOGGING` – set to `1` to enable verbose debug logs and Flask debug mode (default `0`)
-- `LOG_FILE` – path to the rotating log file. Leave empty to disable file
-  logging and use stdout only
+- `LOG_FILE` – path to the rotating log file. The parent directory is created
+  if it does not exist. Leave empty to disable file logging and use stdout only
 - `LOG_MAX_BYTES` – maximum size of the log file before rotation (default 1048576)
 - `LOG_BACKUP_COUNT` – number of rotated log files to keep (default 3)
 - `LISTEN_PORT` – port the application listens on (default `80`)

--- a/backend/app.py
+++ b/backend/app.py
@@ -108,6 +108,9 @@ _log_handlers = [logging.StreamHandler()]
 _file_handler_error = None
 if LOG_FILE:
     try:
+        log_dir = os.path.dirname(LOG_FILE)
+        if log_dir:
+            os.makedirs(log_dir, exist_ok=True)
         _log_handlers.append(
             RotatingFileHandler(
                 LOG_FILE, maxBytes=LOG_MAX_BYTES, backupCount=LOG_BACKUP_COUNT

--- a/tests/test_env_defaults.py
+++ b/tests/test_env_defaults.py
@@ -8,3 +8,12 @@ def test_invalid_int_env_does_not_crash(monkeypatch):
     assert mod.LOG_MAX_BYTES == 1 * 1024 * 1024
     monkeypatch.delenv("LOG_MAX_BYTES", raising=False)
     importlib.reload(sys.modules["hetzner_dyndns.backend.app"])
+
+
+def test_log_file_directory_created(monkeypatch, tmp_path):
+    path = tmp_path / "logs" / "app.log"
+    monkeypatch.setenv("LOG_FILE", str(path))
+    mod = importlib.reload(sys.modules["hetzner_dyndns.backend.app"])
+    assert mod._file_handler_error is None
+    monkeypatch.delenv("LOG_FILE", raising=False)
+    importlib.reload(sys.modules["hetzner_dyndns.backend.app"])


### PR DESCRIPTION
## Summary
- create directory of `LOG_FILE` if needed before setting up RotatingFileHandler
- document automatic directory creation for `LOG_FILE`
- test that setting `LOG_FILE` to a path inside a temporary directory works

## Testing
- `pip install -r requirements-dev.txt`
- `pip install flask requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855500b14d0832187994c1049a42418