### PR TITLE
Handle empty ALLOWED_FQDNS

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -292,7 +292,14 @@ def perform_update(
         send_ntfy("Param Error", "Invalid FQDN", is_error=True)
         return {"error": "Invalid FQDN"}, 400
 
-    if not ALLOWED_FQDNS or fqdn.lower() not in ALLOWED_FQDNS:
+    if not ALLOWED_FQDNS:
+        app.logger.error(
+            "Request from %s attempted update but backend not configured for updates",
+            request.remote_addr,
+        )
+        send_ntfy("Backend Not Configured", fqdn, is_error=True)
+        return {"error": "backend not configured for updates"}, 500
+    if fqdn.lower() not in ALLOWED_FQDNS:
         app.logger.error(
             "Request from %s disallowed fqdn: %s",
             request.remote_addr,


### PR DESCRIPTION
## Summary
- handle empty `ALLOWED_FQDNS` list in backend
- add regression test for this case

## Testing
- `pre-commit run --files backend/app.py tests/test_backend_update.py`

------
https://chatgpt.com/codex/tasks/task_b_685557527fdc8321a89369f8de0777a4