### PR TITLE
Improve ALLOWED_FQDNS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The repository contains two parts:
    `backend/.secrets`. Create a writable `backend/pre-shared-key` file:
 
    If `ALLOWED_FQDNS` is empty, the backend performs no updates.
+   A missing or misspelled variable has the same effect and all updates are rejected.
+   After starting the containers verify the value with:
+
+   ```bash
+   docker compose exec backend env | grep ALLOWED_FQDNS
+   ```
 
    ```bash
    touch backend/pre-shared-key


### PR DESCRIPTION
## Summary
- mention that missing or mis-spelled `ALLOWED_FQDNS` rejects all updates
- show how to check the variable after startup

## Testing
- `pre-commit run --files README.md` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_685558d7d41c8321a098151a694d96b3