### PR TITLE
Fix allowed FQDN validation

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -296,7 +296,7 @@ def perform_update(
         send_ntfy("Param Error", "Invalid FQDN", is_error=True)
         return {"error": "Invalid FQDN"}, 400
 
-    if not ALLOWED_FQDNS or fqdn.lower() not in ALLOWED_FQDNS:
+    if not ALLOWED_FQDNS:
         app.logger.error(
             "Request from %s attempted update but backend not configured for updates",
             request.remote_addr,


### PR DESCRIPTION
## Summary
- ensure disallowed domains return 403
- keep 500 when backend isn't configured

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68555bea3a988321a51eee6570d0fe15