### PR TITLE
Remove ALLOWED_FQDNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,8 @@ The repository contains two parts:
    - `HETZNER_TOKEN` – your Hetzner DNS API token
    - `NTFY_URL` – base URL of your NTFY instance
    - `NTFY_TOPIC` – topic name for notifications
-2. List your hostnames in both `REGISTERED_FQDNS` and `ALLOWED_FQDNS` inside
-   `backend/.secrets`. Create a writable `backend/pre-shared-key` file:
-
-   If `ALLOWED_FQDNS` is empty, the backend performs no updates.
-   A missing or misspelled variable has the same effect and all updates are rejected.
-   After starting the containers verify the value with:
-
-   ```bash
-   docker compose exec backend env | grep ALLOWED_FQDNS
-   ```
+2. List your hostnames in `REGISTERED_FQDNS` inside `backend/.secrets`.
+   Create a writable `backend/pre-shared-key` file:
 
    ```bash
    touch backend/pre-shared-key
@@ -125,7 +117,7 @@ The container reads the following variables which should be provided via a
 - `HETZNER_TOKEN` – API token for the Hetzner DNS API
 - `NTFY_URL` – Base URL of your NTFY instance
 - `NTFY_TOPIC` – Topic name used for notifications
-- `REGISTERED_FQDNS` – comma-separated hostnames to manage
+- `REGISTERED_FQDNS` – comma-separated hostnames to manage. If empty, no updates are performed.
 - `NTFY_USERNAME` / `NTFY_PASSWORD` – credentials for basic auth with NTFY (optional)
 - `DEBUG_LOGGING` – set to `1` to enable verbose debug logs and Flask debug mode (default `0`)
 - `LOG_FILE` – path to the rotating log file. The parent directory is created
@@ -133,8 +125,6 @@ The container reads the following variables which should be provided via a
 - `LOG_MAX_BYTES` – maximum size of the log file before rotation (default 1048576)
 - `LOG_BACKUP_COUNT` – number of rotated log files to keep (default 3)
 - `LISTEN_PORT` – port the application listens on (default `80`)
-- `ALLOWED_FQDNS` – comma-separated list of allowed fully qualified domain names.
-  If empty, no updates are performed.
 - `RECORD_TTL` – TTL for DNS records in seconds (default `21600`)
 - `ZONE_CACHE_TTL` – how long the zone list is cached in seconds (default `86400`)
 - `REQUEST_CACHE_TTL` – cache lifetime for IP/FQDN entries to avoid redundant updates (default `300`)

--- a/backend/.secrets.example
+++ b/backend/.secrets.example
@@ -8,11 +8,10 @@ DEBUG_LOGGING=0
 #LOG_MAX_BYTES=1048576
 #LOG_BACKUP_COUNT=3
 #LISTEN_PORT=80
-# comma-separated list of allowed hostnames, keys generated on startup
+# comma-separated list of hostnames to manage, keys generated on startup
 REGISTERED_FQDNS=host.example.com
 #BASIC_AUTH_USERNAME=
 #BASIC_AUTH_PASSWORD=
-#ALLOWED_FQDNS=host.example.com
 #RECORD_TTL=21600
 #ZONE_CACHE_TTL=86400
 #REQUEST_CACHE_TTL=300

--- a/backend/app.py
+++ b/backend/app.py
@@ -26,11 +26,6 @@ NTFY_URL = os.environ.get("NTFY_URL")
 NTFY_TOPIC = os.environ.get("NTFY_TOPIC")
 NTFY_USERNAME = os.environ.get("NTFY_USERNAME")
 NTFY_PASSWORD = os.environ.get("NTFY_PASSWORD")
-ALLOWED_FQDNS = [
-    h.strip().lower()
-    for h in os.environ.get("ALLOWED_FQDNS", "").split(",")
-    if h.strip()
-]
 BASIC_AUTH_USERNAME = os.environ.get("BASIC_AUTH_USERNAME")
 BASIC_AUTH_PASSWORD = os.environ.get("BASIC_AUTH_PASSWORD")
 
@@ -133,7 +128,6 @@ if _file_handler_error:
 app.logger.setLevel(log_level)
 
 if DEBUG_LOGGING:
-    app.logger.debug("ALLOWED_FQDNS: %s", ALLOWED_FQDNS)
     app.logger.debug("REGISTERED_FQDNS: %s", REGISTERED_FQDNS)
 
 PRE_SHARED_KEYS = _load_pre_shared_keys(REGISTERED_FQDNS)
@@ -296,14 +290,14 @@ def perform_update(
         send_ntfy("Param Error", "Invalid FQDN", is_error=True)
         return {"error": "Invalid FQDN"}, 400
 
-    if not ALLOWED_FQDNS:
+    if not REGISTERED_FQDNS:
         app.logger.error(
             "Request from %s attempted update but backend not configured for updates",
             request.remote_addr,
         )
         send_ntfy("Backend Not Configured", fqdn, is_error=True)
         return {"error": "backend not configured for updates"}, 500
-    if fqdn.lower() not in ALLOWED_FQDNS:
+    if fqdn.lower() not in REGISTERED_FQDNS:
         app.logger.error(
             "Request from %s disallowed fqdn: %s",
             request.remote_addr,

--- a/tests/test_backend_update.py
+++ b/tests/test_backend_update.py
@@ -39,7 +39,7 @@ def set_pre_shared_keys(monkeypatch):
 def allow_fqdns(monkeypatch):
     monkeypatch.setattr(
         backend_app,
-        "ALLOWED_FQDNS",
+        "REGISTERED_FQDNS",
         [
             "host.example.com",
             "host.other.com",
@@ -251,7 +251,7 @@ def test_ip_version_mismatch(monkeypatch):
 
 def test_disallowed_domain(monkeypatch):
     monkeypatch.setattr(backend_app, "HETZNER_TOKEN", "token")
-    monkeypatch.setattr(backend_app, "ALLOWED_FQDNS", ["host.example.com"])
+    monkeypatch.setattr(backend_app, "REGISTERED_FQDNS", ["host.example.com"])
     monkeypatch.setattr(
         backend_app, "ZONE_CACHE", {"zones": None, "expires": 0}
     )
@@ -267,7 +267,7 @@ def test_disallowed_domain(monkeypatch):
 
 def test_backend_not_configured(monkeypatch):
     monkeypatch.setattr(backend_app, "HETZNER_TOKEN", "token")
-    monkeypatch.setattr(backend_app, "ALLOWED_FQDNS", [])
+    monkeypatch.setattr(backend_app, "REGISTERED_FQDNS", [])
     monkeypatch.setattr(backend_app, "send_ntfy", lambda *a, **k: None)
     monkeypatch.setattr(
         backend_app, "ZONE_CACHE", {"zones": None, "expires": 0}


### PR DESCRIPTION
## Summary
- drop ALLOWED_FQDNS option from backend
- update README to rely only on REGISTERED_FQDNS
- adjust secrets example
- adapt tests

## Testing
- `pre-commit run --files backend/app.py README.md backend/.secrets.example tests/test_backend_update.py`

------
https://chatgpt.com/codex/tasks/task_b_68555e1072408321b15fdabd14091aad