### PR TITLE
Limit log spam from cache hits

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -341,7 +341,10 @@ def perform_update(
     now = time.time()
     cached = REQUEST_CACHE.get(cache_key)
     if cached and now < cached.get("expires", 0) and cached.get("ip") == ip:
-        app.logger.info("No change for %s from %s (cache)", fqdn, request.remote_addr)
+        if DEBUG_LOGGING:
+            app.logger.info(
+                "No change for %s from %s (cache)", fqdn, request.remote_addr
+            )
         send_ntfy("DynDNS Success", f"No change for {fqdn} -> {ip}")
         return {"status": "unchanged", "ip": ip}, 200
 


### PR DESCRIPTION
## Summary
- only log cached no-change updates when DEBUG_LOGGING is enabled
- test that cached updates emit log lines only with debug on

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855611e1a3c8321b33cfdf3a7b2dea4