### PR TITLE
Document Python version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The repository contains two parts:
 - **client** – optional container/script calling the backend from the host whose
   IP should be used.
 
+Python 3.8 or newer is required. This is specified by `requires-python = ">=3.8"` in [pyproject.toml](pyproject.toml).
+
 1. Copy [`backend/.secrets.example`](backend/.secrets.example) to
    `backend/.secrets` and fill in at
    least these variables:


### PR DESCRIPTION
## Summary
- document Python 3.8 requirement in quickstart

## Testing
- `pre-commit run --files README.md`

------
https://chatgpt.com/codex/tasks/task_b_685562eef8e8832192bf066744292c7b