### PR TITLE
Update DynDNS connection log messages

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -230,7 +230,7 @@ def update_connection(url: str, *, now: float | None = None) -> None:
     start_thread = False
     with _CONNECTION_LOCK:
         if url not in ESTABLISHED_CONNECTIONS:
-            app.logger.info("dyndns connection established with %s", url)
+            app.logger.info("DynDNS connection established with %s", url)
             start_thread = True
         ESTABLISHED_CONNECTIONS[url] = now
     if start_thread:
@@ -247,7 +247,7 @@ def check_connections(*, now: float | None = None) -> None:
             if now - ts > LOST_CONNECTION_TIMEOUT:
                 expired.append(url)
     for url in expired:
-        app.logger.error("lost dyndns connection to %s", url)
+        app.logger.error("Lost DynDNS connection to %s", url)
         send_ntfy("DynDNS Lost Connection", f"Lost dyndns connection to {url}", is_error=True)
         with _CONNECTION_LOCK:
             ESTABLISHED_CONNECTIONS.pop(url, None)

--- a/tests/test_backend_update.py
+++ b/tests/test_backend_update.py
@@ -560,7 +560,7 @@ def test_monitor_update_connection(monkeypatch):
 
     monkeypatch.setattr(backend_app.app.logger, "info", fake_info)
     backend_app.update_connection("host.example.com", now=1)
-    assert "dyndns connection established with host.example.com" in logs
+    assert "DynDNS connection established with host.example.com" in logs
     logs.clear()
     backend_app.update_connection("host.example.com", now=2)
     assert logs == []
@@ -586,7 +586,7 @@ def test_monitor_check_connections(monkeypatch):
 
     monkeypatch.setattr(backend_app.app.logger, "error", fake_error)
     backend_app.check_connections(now=20)
-    assert "lost dyndns connection to host.example.com" in errors[0]
+    assert "Lost DynDNS connection to host.example.com" in errors[0]
     assert "host.example.com" in sent["msg"]
     assert backend_app.ESTABLISHED_CONNECTIONS == {}
 


### PR DESCRIPTION
## Summary
- log when a DynDNS connection has been established with capitalized message
- log lost DynDNS connections with capitalized message
- update tests for new log strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685562eef3e08321a2924ab36e285389