### PR TITLE
Log cache no-change only when debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Hetzner again.  The zone list is cached for 24&nbsp;hours by default and DNS
 records are created with a 6&nbsp;hour TTL.  These values can be adjusted via the
 `ZONE_CACHE_TTL` and `RECORD_TTL` environment variables.  The request-level
 cache lifetime is controlled by `REQUEST_CACHE_TTL`.
+The "no change (cache)" log entry is only emitted when debug logging is enabled.
 
 The backend authenticates requests using per-host pre-shared keys stored in
 `./pre-shared-key` on the host and mounted into the container at

--- a/backend/app.py
+++ b/backend/app.py
@@ -341,7 +341,10 @@ def perform_update(
     now = time.time()
     cached = REQUEST_CACHE.get(cache_key)
     if cached and now < cached.get("expires", 0) and cached.get("ip") == ip:
-        app.logger.info("No change for %s from %s (cache)", fqdn, request.remote_addr)
+        if DEBUG_LOGGING:
+            app.logger.info(
+                "No change for %s from %s (cache)", fqdn, request.remote_addr
+            )
         send_ntfy("DynDNS Success", f"No change for {fqdn} -> {ip}")
         return {"status": "unchanged", "ip": ip}, 200
 


### PR DESCRIPTION
## Summary
- show cached no-change log only when debug logging is enabled
- document that cached no-change log messages require debug logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6855611e1a3c8321b33cfdf3a7b2dea4