### PR TITLE
Add priority 4 to connection lost notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ to the file. Use the matching key from this file for every client.
 The backend keeps track of the last successful update for each configured
 hostname. A background task periodically checks these timestamps and if a host
 stops updating for longer than `LOST_CONNECTION_TIMEOUT` seconds an error
-message is logged and a notification is sent via ntfy.
+message is logged and a notification is sent via ntfy. Lost connection
+notifications are sent with priority `4` so that ntfy clients trigger a long
+vibration burst and pop-over alert.
 
 When using Docker Compose, make sure the file exists and is writable by the
 container user. Otherwise Docker may create a directory instead of a file and

--- a/backend/app.py
+++ b/backend/app.py
@@ -192,7 +192,13 @@ def find_zone(fqdn: str, zones):
     return None, None, None
 
 
-def send_ntfy(title: str, message: str, *, is_error: bool = False) -> None:
+def send_ntfy(
+    title: str,
+    message: str,
+    *,
+    is_error: bool = False,
+    priority: int | None = None,
+) -> None:
     """Send a notification via ntfy.
 
     Success messages are only emitted when ``DEBUG_LOGGING`` is enabled. Error
@@ -204,6 +210,8 @@ def send_ntfy(title: str, message: str, *, is_error: bool = False) -> None:
     if not NTFY_URL:
         return
     headers = {"Title": title} if title else {}
+    if priority is not None:
+        headers["Priority"] = str(priority)
     auth = None
     if NTFY_USERNAME and NTFY_PASSWORD:
         auth = (NTFY_USERNAME, NTFY_PASSWORD)
@@ -248,7 +256,12 @@ def check_connections(*, now: float | None = None) -> None:
                 expired.append(url)
     for url in expired:
         app.logger.error("Lost DynDNS connection to %s", url)
-        send_ntfy("DynDNS Lost Connection", f"Lost dyndns connection to {url}", is_error=True)
+        send_ntfy(
+            "DynDNS Lost Connection",
+            f"Lost dyndns connection to {url}",
+            is_error=True,
+            priority=4,
+        )
         with _CONNECTION_LOCK:
             ESTABLISHED_CONNECTIONS.pop(url, None)
 

--- a/tests/test_backend_update.py
+++ b/tests/test_backend_update.py
@@ -575,8 +575,9 @@ def test_monitor_check_connections(monkeypatch):
     monkeypatch.setattr(backend_app, "LOST_CONNECTION_TIMEOUT", 10)
     sent = {}
 
-    def fake_ntfy(t, m, *, is_error=False):
+    def fake_ntfy(t, m, *, is_error=False, priority=None):
         sent["msg"] = m
+        sent["priority"] = priority
 
     monkeypatch.setattr(backend_app, "send_ntfy", fake_ntfy)
     errors = []
@@ -588,6 +589,7 @@ def test_monitor_check_connections(monkeypatch):
     backend_app.check_connections(now=20)
     assert "Lost DynDNS connection to host.example.com" in errors[0]
     assert "host.example.com" in sent["msg"]
+    assert sent["priority"] == 4
     assert backend_app.ESTABLISHED_CONNECTIONS == {}
 
 

--- a/tests/test_send_ntfy.py
+++ b/tests/test_send_ntfy.py
@@ -81,3 +81,24 @@ def test_send_ntfy_logs_warning(monkeypatch):
 
     backend_app.send_ntfy("t", "m")
     assert "500" in logs[0]
+
+
+def test_send_ntfy_priority(monkeypatch):
+    called = {}
+
+    class DummyResp:
+        status_code = 200
+        ok = True
+        text = ""
+
+    def mock_post(url, headers=None, data=None, auth=None, timeout=None):
+        called["headers"] = headers
+        return DummyResp()
+
+    monkeypatch.setattr(backend_app.requests, "post", mock_post)
+    monkeypatch.setattr(backend_app, "NTFY_URL", "http://ntfy")
+    monkeypatch.setattr(backend_app, "NTFY_TOPIC", None)
+    monkeypatch.setattr(backend_app, "DEBUG_LOGGING", True)
+
+    backend_app.send_ntfy("t", "m", priority=4)
+    assert called["headers"]["Priority"] == "4"


### PR DESCRIPTION
## Summary
- add optional `priority` parameter to `send_ntfy`
- mark lost connection alerts with priority 4
- test ntfy priority handling and update connection tests
- document priority 4 in README

## Testing
- `pip install -r backend/requirements.txt`
- `pip install -r client/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685564bbf6c48321b2012655b0a0e46d