### PR TITLE
Add admin API planning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,12 @@ The container reads the following variables which should be provided via a
 - `LOST_CONNECTION_TIMEOUT` – seconds without updates before a client is considered offline (default `10800`)
 - `CONNECTION_CHECK_INTERVAL` – how often to check for lost connections (default `60`)
 - `BASIC_AUTH_USERNAME` / `BASIC_AUTH_PASSWORD` – enable HTTP basic auth for the update endpoints
+- `API_TOKEN` – token required to access the administrative API (optional)
 
 Numeric values that cannot be parsed fall back to the defaults above and generate a warning in the log.
+
+Further information about the planned administration API can be found in
+[`docs/backend_api.md`](docs/backend_api.md).
 
 ## Client
 

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -46,6 +46,18 @@ Response body:
 { "fqdn": "host.example.com", "token": "..." }
 ```
 
+### `POST /reset/<fqdn>`
+Generates a new token for the given FQDN.
+
+This endpoint is intended to be used when a customer requests a reset via the
+webshop. The webshop verifies the user's email and then calls this API to obtain
+a fresh token which is shown once to the customer.
+
+Response body:
+```json
+{ "fqdn": "host.example.com", "token": "..." }
+```
+
 ## Configuration
 
 A new environment variable `API_TOKEN` will hold the administrative token. The
@@ -61,8 +73,8 @@ is read and all entries are loaded into memory.
 1. Extend `backend/app.py`
    - Load `API_TOKEN` from the environment.
    - Add helper functions to read and write the `pre-shared-key` file.
-   - Implement the `/register` and `/token/<fqdn>` routes with token
-     authentication.
+   - Implement the `/register`, `/token/<fqdn>` and `/reset/<fqdn>` routes with
+     token authentication.
 2. Write unit tests covering the new functionality.
 3. Document the new API in the main `README.md`.
 

--- a/docs/backend_api.md
+++ b/docs/backend_api.md
@@ -1,0 +1,70 @@
+# Backend Automation API (Backend-AP)
+
+This document outlines the planned API extension to automate the Hetzner DynDNS
+backend. The goal is to allow external systems (e.g. a webshop) to create new
+DynDNS entries and retrieve their tokens automatically.
+
+## Overview
+
+The backend will expose a small administrative API which is protected by a
+single API token. Through this API a new fully qualified domain name (FQDN) can
+be registered and the associated pre‑shared token can be queried. The token will
+then be sent to the end user by the webshop.
+
+All calls must include the header `X-Api-Token` with the value configured in the
+backend. Without this token the request is rejected.
+
+## Planned Endpoints
+
+### `POST /register`
+Registers a new FQDN and returns the generated token.
+
+Request body:
+```json
+{ "fqdn": "host.example.com" }
+```
+
+Response body:
+```json
+{ "fqdn": "host.example.com", "token": "..." }
+```
+
+If the FQDN already exists, the existing token is returned. The FQDN is stored in
+the `pre-shared-key` file so that it persists across restarts.
+
+### `GET /token/<fqdn>`
+Returns the token for an already registered FQDN.
+
+Example:
+```bash
+curl -H "X-Api-Token: <admin-token>" \
+     https://backend.example.com/token/host.example.com
+```
+
+Response body:
+```json
+{ "fqdn": "host.example.com", "token": "..." }
+```
+
+## Configuration
+
+A new environment variable `API_TOKEN` will hold the administrative token. The
+backend must be restarted after changing this value. When no token is set, the
+administrative API is disabled.
+
+Tokens for registered FQDNs are stored in `backend/pre-shared-key`. This file is
+updated whenever a new FQDN is registered through the API. On startup the file
+is read and all entries are loaded into memory.
+
+## Implementation Tasks
+
+1. Extend `backend/app.py`
+   - Load `API_TOKEN` from the environment.
+   - Add helper functions to read and write the `pre-shared-key` file.
+   - Implement the `/register` and `/token/<fqdn>` routes with token
+     authentication.
+2. Write unit tests covering the new functionality.
+3. Document the new API in the main `README.md`.
+
+After these steps the webshop can call the administrative API to register new
+FQDNs and distribute the generated tokens to customers.

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -1,0 +1,56 @@
+from hetzner_dyndns.backend import app as backend_app
+
+
+def setup_admin(monkeypatch):
+    monkeypatch.setattr(backend_app, "API_TOKEN", "admintoken")
+    monkeypatch.setattr(backend_app, "REGISTERED_FQDNS", [])
+    monkeypatch.setattr(backend_app, "PRE_SHARED_KEYS", {})
+    monkeypatch.setattr(backend_app, "_write_pre_shared_keys", lambda keys: None)
+
+
+def test_register_returns_token(monkeypatch):
+    setup_admin(monkeypatch)
+    client = backend_app.app.test_client()
+    resp = client.post(
+        "/register",
+        json={"fqdn": "host.example.com"},
+        headers={"X-Api-Token": "admintoken"},
+    )
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert data["fqdn"] == "host.example.com"
+    assert backend_app.PRE_SHARED_KEYS["host.example.com"] == data["token"]
+
+
+def test_get_token(monkeypatch):
+    setup_admin(monkeypatch)
+    backend_app.PRE_SHARED_KEYS["host.example.com"] = "secret"
+    backend_app.REGISTERED_FQDNS.append("host.example.com")
+    client = backend_app.app.test_client()
+    resp = client.get(
+        "/token/host.example.com",
+        headers={"X-Api-Token": "admintoken"},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json() == {"fqdn": "host.example.com", "token": "secret"}
+
+
+def test_reset_token(monkeypatch):
+    setup_admin(monkeypatch)
+    backend_app.PRE_SHARED_KEYS["host.example.com"] = "old"
+    backend_app.REGISTERED_FQDNS.append("host.example.com")
+    tokens = {}
+
+    def capture(keys):
+        tokens.update(keys)
+
+    monkeypatch.setattr(backend_app, "_write_pre_shared_keys", capture)
+    client = backend_app.app.test_client()
+    resp = client.post(
+        "/reset/host.example.com",
+        headers={"X-Api-Token": "admintoken"},
+    )
+    assert resp.status_code == 200
+    new_token = resp.get_json()["token"]
+    assert new_token != "old"
+    assert tokens["host.example.com"] == new_token

--- a/tests/test_backend_update.py
+++ b/tests/test_backend_update.py
@@ -774,5 +774,5 @@ def test_request_cache_logs_only_in_debug(monkeypatch):
         headers={"X-Pre-Shared-Key": "test"},
     )
     assert resp.status_code == 200
-    assert any("(cache)" in l for l in logs)
+    assert any("(cache)" in line for line in logs)
     assert call_count["post"] == 1


### PR DESCRIPTION
## Summary
- document planned admin API token endpoint and configuration
- add docs on new Backend-AP design
- fix flake8 warning in tests

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_b_685805dd580c83219b7c8f5c847c7fbb