### PR TITLE
Migrate backend to Hetzner Cloud Console DNS RRSet API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Python 3.8 or newer is required. This is specified by `requires-python = ">=3.8"
 1. Copy [`backend/.secrets.example`](backend/.secrets.example) to
    `backend/.secrets` and fill in at
    least these variables:
-   - `HETZNER_TOKEN` – your Hetzner DNS API token
+   - `HETZNER_TOKEN` – your Hetzner Cloud API token (from Hetzner Console)
    - `NTFY_URL` – base URL of your NTFY instance
    - `NTFY_TOPIC` – topic name for notifications
 2. List your hostnames in `REGISTERED_FQDNS` inside `backend/.secrets`.
@@ -63,15 +63,22 @@ front of the containers.
 ---
 
 This project provides a lightweight REST API for updating Hetzner DNS A/AAAA records.
-It consists of a backend service that communicates with the Hetzner DNS API and
+It consists of a backend service that communicates with the Hetzner Cloud Console DNS API and
 an optional client that can be run on remote systems to trigger updates.
 
 ## Backend
 
 The backend is a small Flask application exposing two endpoints. `/update`
 accepts JSON payloads while `/nic/update` follows the dyndns2 protocol for
-routers and other dynamic DNS clients. The `/update` endpoint expects JSON of
-the form:
+routers and other dynamic DNS clients.
+
+DNS updates use Hetzner's Cloud Console API (`https://api.hetzner.cloud/v1`)
+with Bearer authentication. The service lists zones via `/zones`, lists RRSets
+via `/zones/{zone}/rrsets`, creates records via `POST /zones/{zone}/rrsets`,
+and updates existing entries via
+`PUT /zones/{zone}/rrsets/{name}/{type}/actions/set_records`.
+
+The `/update` endpoint expects JSON of the form:
 
 ```json
 { "fqdn": "host.example.com", "ip": "1.2.3.4" }
@@ -126,7 +133,7 @@ chmod 600 backend/pre-shared-key
 The container reads the following variables which should be provided via a
 `backend/.secrets` file or other means:
 
-- `HETZNER_TOKEN` – API token for the Hetzner DNS API
+- `HETZNER_TOKEN` – API token for the Hetzner Cloud API (Authorization: Bearer <token>)
 - `NTFY_URL` – Base URL of your NTFY instance
 - `NTFY_TOPIC` – Topic name used for notifications
 - `REGISTERED_FQDNS` – comma-separated hostnames to manage. If empty, no updates are performed.

--- a/backend/app.py
+++ b/backend/app.py
@@ -42,6 +42,15 @@ REQUEST_CACHE_TTL = _get_int_env("REQUEST_CACHE_TTL", 300)  # seconds
 # Default TTL for created or updated DNS records
 RECORD_TTL = _get_int_env("RECORD_TTL", 21600)
 
+HETZNER_API_BASE = "https://api.hetzner.cloud/v1"
+
+
+def _hetzner_headers(*, json_request: bool = False) -> dict[str, str]:
+    headers = {"Authorization": f"Bearer {HETZNER_TOKEN}"}
+    if json_request:
+        headers["Content-Type"] = "application/json"
+    return headers
+
 # Pre-shared key configuration
 PRE_SHARED_KEY_FILE = "/pre-shared-key"
 REGISTERED_FQDNS = [
@@ -145,8 +154,8 @@ def get_zones(force_refresh: bool = False):
 
     try:
         resp = requests.get(
-            "https://dns.hetzner.com/api/v1/zones",
-            headers={"Auth-API-Token": HETZNER_TOKEN},
+            f"{HETZNER_API_BASE}/zones",
+            headers=_hetzner_headers(),
             timeout=10,
         )
     except requests.RequestException as exc:
@@ -363,8 +372,8 @@ def perform_update(
 
     try:
         records_resp = requests.get(
-            f"https://dns.hetzner.com/api/v1/records?zone_id={zone_id}",
-            headers={"Auth-API-Token": HETZNER_TOKEN},
+            f"{HETZNER_API_BASE}/zones/{zone_id}/rrsets",
+            headers=_hetzner_headers(),
             timeout=10,
         )
     except requests.RequestException as exc:
@@ -383,39 +392,33 @@ def perform_update(
         send_ntfy("Records Fetch Failed", records_resp.text, is_error=True)
         return {"error": "Failed to fetch records"}, 500
 
-    record_id = None
-    current_value = None
-    for record in records_resp.json().get("records", []):
+    record_name = None
+    current_values = []
+    for rrset in records_resp.json().get("rrsets", []):
+        records = rrset.get("records") or []
         if (
-            record.get("name") == subdomain
-            and record.get("type") == record_type
+            rrset.get("name") == subdomain
+            and rrset.get("type") == record_type
         ):
-            record_id = record.get("id")
-            current_value = record.get("value")
+            record_name = rrset.get("name")
+            current_values = [r.get("value") for r in records if r.get("value")]
             break
 
-    if record_id and skip_no_change and current_value == ip:
+    if record_name and skip_no_change and ip in current_values:
         app.logger.info("No change for %s from %s", fqdn, request.remote_addr)
         send_ntfy("DynDNS Success", f"No change for {fqdn} -> {ip}")
         REQUEST_CACHE[cache_key] = {"ip": ip, "expires": now + REQUEST_CACHE_TTL}
         return {"status": "unchanged", "ip": ip}, 200
 
     payload = {
-        "value": ip,
-        "ttl": RECORD_TTL,
-        "type": record_type,
-        "name": subdomain,
-        "zone_id": zone_id,
+        "records": [{"value": ip}],
     }
 
-    if record_id:
+    if record_name:
         try:
             resp = requests.put(
-                f"https://dns.hetzner.com/api/v1/records/{record_id}",
-                headers={
-                    "Auth-API-Token": HETZNER_TOKEN,
-                    "Content-Type": "application/json",
-                },
+                f"{HETZNER_API_BASE}/zones/{zone_id}/rrsets/{record_name}/{record_type}/actions/set_records",
+                headers=_hetzner_headers(json_request=True),
                 json=payload,
                 timeout=10,
             )
@@ -429,13 +432,17 @@ def perform_update(
             return {"error": "Failed to update record"}, 500
         action = "Updated"
     else:
+        payload.update(
+            {
+                "ttl": RECORD_TTL,
+                "type": record_type,
+                "name": subdomain,
+            }
+        )
         try:
             resp = requests.post(
-                "https://dns.hetzner.com/api/v1/records",
-                headers={
-                    "Auth-API-Token": HETZNER_TOKEN,
-                    "Content-Type": "application/json",
-                },
+                f"{HETZNER_API_BASE}/zones/{zone_id}/rrsets",
+                headers=_hetzner_headers(json_request=True),
                 json=payload,
                 timeout=10,
             )

--- a/tests/test_backend_update.py
+++ b/tests/test_backend_update.py
@@ -68,12 +68,12 @@ def test_update_creates_record(monkeypatch):
     def mock_get(url, headers=None, **kwargs):
         if url.endswith("/zones"):
             return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
-        elif url.startswith("https://dns.hetzner.com/api/v1/records"):
-            return DummyResp({"records": []})
+        elif url.startswith("https://api.hetzner.cloud/v1/zones/z1/rrsets"):
+            return DummyResp({"rrsets": []})
         raise AssertionError("unexpected GET " + url)
 
     def mock_post(url, headers=None, json=None, **kwargs):
-        assert url.endswith("/records")
+        assert url.endswith("/rrsets")
         return DummyResp({"record": {"id": "r1"}})
 
     monkeypatch.setattr(backend_app.requests, "get", mock_get)
@@ -128,14 +128,14 @@ def test_update_updates_record(monkeypatch):
     def mock_get(url, headers=None, **kwargs):
         if url.endswith("/zones"):
             return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
-        elif url.startswith("https://dns.hetzner.com/api/v1/records"):
+        elif url.startswith("https://api.hetzner.cloud/v1/zones/z1/rrsets"):
             return DummyResp(
-                {"records": [{"id": "r1", "name": "host", "type": "A"}]}
+                {"rrsets": [{"name": "host", "type": "A", "records": [{"value": "1.1.1.1"}]}]}
             )
         raise AssertionError("unexpected GET " + url)
 
     def mock_put(url, headers=None, json=None, **kwargs):
-        assert url.endswith("/records/r1")
+        assert url.endswith("/rrsets/host/A/actions/set_records")
         return DummyResp({"record": {"id": "r1"}})
 
     monkeypatch.setattr(backend_app.requests, "get", mock_get)
@@ -166,12 +166,12 @@ def test_update_api_failure(monkeypatch):
     def mock_get(url, headers=None, **kwargs):
         if url.endswith("/zones"):
             return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
-        elif url.startswith("https://dns.hetzner.com/api/v1/records"):
-            return DummyResp({"records": []})
+        elif url.startswith("https://api.hetzner.cloud/v1/zones/z1/rrsets"):
+            return DummyResp({"rrsets": []})
         raise AssertionError("unexpected GET " + url)
 
     def mock_post(url, headers=None, json=None, **kwargs):
-        assert url.endswith("/records")
+        assert url.endswith("/rrsets")
         return DummyResp({"error": "fail"}, status_code=500)
 
     monkeypatch.setattr(backend_app.requests, "get", mock_get)
@@ -213,13 +213,13 @@ def test_ipv6_record(monkeypatch):
     def mock_get(url, headers=None, **kwargs):
         if url.endswith("/zones"):
             return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
-        elif url.startswith("https://dns.hetzner.com/api/v1/records"):
-            return DummyResp({"records": []})
+        elif url.startswith("https://api.hetzner.cloud/v1/zones/z1/rrsets"):
+            return DummyResp({"rrsets": []})
         raise AssertionError("unexpected GET " + url)
 
     def mock_post(url, headers=None, json=None, **kwargs):
         assert json["type"] == "AAAA"
-        assert json["value"] == "2001:db8::1"
+        assert json["records"] == [{"value": "2001:db8::1"}]
         return DummyResp({"record": {"id": "r1"}})
 
     monkeypatch.setattr(backend_app.requests, "get", mock_get)
@@ -300,13 +300,13 @@ def test_update_multi_level_zone(monkeypatch):
                 }
             )
         elif url.startswith(
-            "https://dns.hetzner.com/api/v1/records?zone_id=z2"
+            "https://api.hetzner.cloud/v1/zones/z2/rrsets"
         ):
-            return DummyResp({"records": []})
+            return DummyResp({"rrsets": []})
         raise AssertionError("unexpected GET " + url)
 
     def mock_post(url, headers=None, json=None, **kwargs):
-        assert json["zone_id"] == "z2"
+        assert url.endswith("/zones/z2/rrsets")
         assert json["name"] == "host"
         return DummyResp({"record": {"id": "r1"}})
 
@@ -392,8 +392,8 @@ def test_basic_auth(monkeypatch):
     def mock_get(url, headers=None, **kwargs):
         if url.endswith("/zones"):
             return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
-        elif url.startswith("https://dns.hetzner.com/api/v1/records"):
-            return DummyResp({"records": []})
+        elif url.startswith("https://api.hetzner.cloud/v1/zones/z1/rrsets"):
+            return DummyResp({"rrsets": []})
         raise AssertionError("unexpected GET " + url)
 
     def mock_post(url, headers=None, json=None, **kwargs):
@@ -425,8 +425,8 @@ def test_nic_update(monkeypatch):
     def mock_get(url, headers=None, **kwargs):
         if url.endswith("/zones"):
             return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
-        elif url.startswith("https://dns.hetzner.com/api/v1/records"):
-            return DummyResp({"records": []})
+        elif url.startswith("https://api.hetzner.cloud/v1/zones/z1/rrsets"):
+            return DummyResp({"rrsets": []})
         raise AssertionError("unexpected GET " + url)
 
     def mock_post(url, headers=None, json=None, **kwargs):
@@ -458,8 +458,8 @@ def test_nic_update_query_auth(monkeypatch):
     def mock_get(url, headers=None, **kwargs):
         if url.endswith("/zones"):
             return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
-        elif url.startswith("https://dns.hetzner.com/api/v1/records"):
-            return DummyResp({"records": []})
+        elif url.startswith("https://api.hetzner.cloud/v1/zones/z1/rrsets"):
+            return DummyResp({"rrsets": []})
         raise AssertionError("unexpected GET " + url)
 
     def mock_post(url, headers=None, json=None, **kwargs):
@@ -487,8 +487,8 @@ def test_record_ttl_from_env(monkeypatch):
     def mock_get(url, headers=None, **kwargs):
         if url.endswith("/zones"):
             return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
-        elif url.startswith("https://dns.hetzner.com/api/v1/records"):
-            return DummyResp({"records": []})
+        elif url.startswith("https://api.hetzner.cloud/v1/zones/z1/rrsets"):
+            return DummyResp({"rrsets": []})
         raise AssertionError("unexpected GET " + url)
 
     captured = {}
@@ -518,8 +518,8 @@ def test_request_cache_skips_duplicate(monkeypatch):
     def mock_get(url, headers=None, **kwargs):
         if url.endswith("/zones"):
             return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
-        elif url.startswith("https://dns.hetzner.com/api/v1/records"):
-            return DummyResp({"records": []})
+        elif url.startswith("https://api.hetzner.cloud/v1/zones/z1/rrsets"):
+            return DummyResp({"rrsets": []})
         raise AssertionError("unexpected GET " + url)
 
     call_count = {"post": 0}
@@ -610,8 +610,8 @@ def test_perform_update_purges_cache(monkeypatch):
     def mock_get(url, headers=None, **kwargs):
         if url.endswith("/zones"):
             return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
-        elif url.startswith("https://dns.hetzner.com/api/v1/records"):
-            return DummyResp({"records": []})
+        elif url.startswith("https://api.hetzner.cloud/v1/zones/z1/rrsets"):
+            return DummyResp({"rrsets": []})
         raise AssertionError("unexpected GET " + url)
 
     post_calls = {"count": 0}
@@ -731,8 +731,8 @@ def test_request_cache_logs_only_in_debug(monkeypatch):
     def mock_get(url, headers=None, **kwargs):
         if url.endswith("/zones"):
             return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
-        elif url.startswith("https://dns.hetzner.com/api/v1/records"):
-            return DummyResp({"records": []})
+        elif url.startswith("https://api.hetzner.cloud/v1/zones/z1/rrsets"):
+            return DummyResp({"rrsets": []})
         raise AssertionError("unexpected GET " + url)
 
     call_count = {"post": 0}


### PR DESCRIPTION
### Motivation
- The legacy Hetzner DNS API endpoints are removed and the service must use the Hetzner Cloud/Console DNS API (`https://api.hetzner.cloud/v1`) which exposes RRSets and requires Bearer authentication. 
- Update/create semantics and payloads differ (RRSet model), so the backend must list zones/rrsets and create or overwrite RRSet records using the new endpoints. 

### Description
- Introduced `HETZNER_API_BASE` and a helper `
_hetzner_headers(json_request=True)` to centralize `Authorization: Bearer <token>` and `Content-Type` handling. 
- Replaced legacy endpoints with Cloud API calls: `GET /zones`, `GET /zones/{zone}/rrsets`, `POST /zones/{zone}/rrsets`, and `PUT /zones/{zone}/rrsets/{name}/{type}/actions/set_records`, and adapted request/response parsing accordingly in `backend/app.py`. 
- Switched payload formats to RRSet-style bodies (use `records: [{"value": ...}]` for updates/creates) and adjusted no-change detection to compare against the RRSet `records` array. 
- Updated `tests/test_backend_update.py` to mock and validate the new Cloud RRSet endpoints and payload shapes, and updated `README.md` to document Bearer auth and the Cloud API endpoints. 

### Testing
- Ran the test suite with `pytest -q` and all tests passed: `46 passed`.
- Updated unit tests now cover new `rrsets` endpoints, create and `set_records` update flows and payload assertions, and they succeeded under the new code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698d08a0fb488321ba65717849c704d5)