### PR TITLE
Use Hetzner RRSet ID when updating DNS records

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ DNS updates use Hetzner's Cloud Console API (`https://api.hetzner.cloud/v1`)
 with Bearer authentication. The service lists zones via `/zones`, lists RRSets
 via `/zones/{zone}/rrsets`, creates records via `POST /zones/{zone}/rrsets`,
 and updates existing entries via
-`PUT /zones/{zone}/rrsets/{name}/{type}/actions/set_records`.
+`PUT /zones/{zone}/rrsets/{id}/actions/set_records` (using the RRSet ID returned by the list endpoint).
 
 The `/update` endpoint expects JSON of the form:
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -392,7 +392,8 @@ def perform_update(
         send_ntfy("Records Fetch Failed", records_resp.text, is_error=True)
         return {"error": "Failed to fetch records"}, 500
 
-    record_name = None
+    record_id = None
+    record_found = False
     current_values = []
     for rrset in records_resp.json().get("rrsets", []):
         records = rrset.get("records") or []
@@ -400,11 +401,22 @@ def perform_update(
             rrset.get("name") == subdomain
             and rrset.get("type") == record_type
         ):
-            record_name = rrset.get("name")
+            record_found = True
+            record_id = rrset.get("id")
             current_values = [r.get("value") for r in records if r.get("value")]
             break
 
-    if record_name and skip_no_change and ip in current_values:
+    if record_found and not record_id:
+        app.logger.error(
+            "Record id missing for %s (%s) from %s",
+            fqdn,
+            record_type,
+            request.remote_addr,
+        )
+        send_ntfy("Records Fetch Failed", "Record id missing", is_error=True)
+        return {"error": "Failed to fetch records"}, 500
+
+    if record_id and skip_no_change and ip in current_values:
         app.logger.info("No change for %s from %s", fqdn, request.remote_addr)
         send_ntfy("DynDNS Success", f"No change for {fqdn} -> {ip}")
         REQUEST_CACHE[cache_key] = {"ip": ip, "expires": now + REQUEST_CACHE_TTL}
@@ -414,10 +426,10 @@ def perform_update(
         "records": [{"value": ip}],
     }
 
-    if record_name:
+    if record_id:
         try:
             resp = requests.put(
-                f"{HETZNER_API_BASE}/zones/{zone_id}/rrsets/{record_name}/{record_type}/actions/set_records",
+                f"{HETZNER_API_BASE}/zones/{zone_id}/rrsets/{record_id}/actions/set_records",
                 headers=_hetzner_headers(json_request=True),
                 json=payload,
                 timeout=10,

--- a/tests/test_backend_update.py
+++ b/tests/test_backend_update.py
@@ -130,12 +130,12 @@ def test_update_updates_record(monkeypatch):
             return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
         elif url.startswith("https://api.hetzner.cloud/v1/zones/z1/rrsets"):
             return DummyResp(
-                {"rrsets": [{"name": "host", "type": "A", "records": [{"value": "1.1.1.1"}]}]}
+                {"rrsets": [{"id": "r1", "name": "host", "type": "A", "records": [{"value": "1.1.1.1"}]}]}
             )
         raise AssertionError("unexpected GET " + url)
 
     def mock_put(url, headers=None, json=None, **kwargs):
-        assert url.endswith("/rrsets/host/A/actions/set_records")
+        assert url.endswith("/rrsets/r1/actions/set_records")
         return DummyResp({"record": {"id": "r1"}})
 
     monkeypatch.setattr(backend_app.requests, "get", mock_get)
@@ -149,6 +149,34 @@ def test_update_updates_record(monkeypatch):
     )
     assert resp.status_code == 200
     assert resp.get_json() == {"status": "updated", "ip": "1.2.3.4"}
+
+
+def test_update_record_without_id_fails(monkeypatch):
+    monkeypatch.setattr(backend_app, "HETZNER_TOKEN", "token")
+    monkeypatch.setattr(backend_app, "send_ntfy", lambda *a, **k: None)
+    monkeypatch.setattr(
+        backend_app, "ZONE_CACHE", {"zones": None, "expires": 0}
+    )
+
+    def mock_get(url, headers=None, **kwargs):
+        if url.endswith("/zones"):
+            return DummyResp({"zones": [{"id": "z1", "name": "example.com"}]})
+        elif url.startswith("https://api.hetzner.cloud/v1/zones/z1/rrsets"):
+            return DummyResp(
+                {"rrsets": [{"name": "host", "type": "A", "records": [{"value": "1.1.1.1"}]}]}
+            )
+        raise AssertionError("unexpected GET " + url)
+
+    monkeypatch.setattr(backend_app.requests, "get", mock_get)
+
+    client = backend_app.app.test_client()
+    resp = client.post(
+        "/update",
+        json={"fqdn": "host.example.com", "ip": "1.2.3.4"},
+        headers={"X-Pre-Shared-Key": "test"},
+    )
+    assert resp.status_code == 500
+    assert resp.get_json() == {"error": "Failed to fetch records"}
 
 
 def test_update_api_failure(monkeypatch):


### PR DESCRIPTION
### Motivation
- The Hetzner DNS API requires using the RRSet `id` returned by the list endpoint when calling `set_records`, but the update flow was constructing the PUT URL using the record name/type which produced 404s. 
- The RRSet list response may match name/type but occasionally be missing an `id`, which must be handled instead of constructing an invalid update call. 

### Description
- Change backend logic to read and use the RRSet `id` from `/zones/{zone}/rrsets` and call `PUT /zones/{zone_id}/rrsets/{record_id}/actions/set_records` for updates. 
- Add a guard that logs and returns an error if a matching RRSet (name+type) is found but lacks an `id`. 
- Update `tests/test_backend_update.py` to assert ID-based update URLs and add a test validating failure when an RRSet has no `id`. 
- Update `README.md` to document the correct `set_records` endpoint shape using the RRSet ID. 

### Testing
- Ran the test suite with `pytest -q` and all tests passed: `47 passed`. 
- Unit tests were added/modified in `tests/test_backend_update.py` to cover the ID-based update and missing-ID failure cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698dd3c02f4083218820f8ca0c2447e9)