### PR TITLE
Use POST for Hetzner rrset update action

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ DNS updates use Hetzner's Cloud Console API (`https://api.hetzner.cloud/v1`)
 with Bearer authentication. The service lists zones via `/zones`, lists RRSets
 via `/zones/{zone}/rrsets`, creates records via `POST /zones/{zone}/rrsets`,
 and updates existing entries via
-`PUT /zones/{zone}/rrsets/{id}/actions/set_records` (using the RRSet ID returned by the list endpoint).
+`POST /zones/{zone}/rrsets/{id}/actions/set_records` (using the RRSet ID returned by the list endpoint).
 
 The `/update` endpoint expects JSON of the form:
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -428,7 +428,7 @@ def perform_update(
 
     if record_id:
         try:
-            resp = requests.put(
+            resp = requests.post(
                 f"{HETZNER_API_BASE}/zones/{zone_id}/rrsets/{record_id}/actions/set_records",
                 headers=_hetzner_headers(json_request=True),
                 json=payload,

--- a/tests/test_backend_update.py
+++ b/tests/test_backend_update.py
@@ -134,12 +134,12 @@ def test_update_updates_record(monkeypatch):
             )
         raise AssertionError("unexpected GET " + url)
 
-    def mock_put(url, headers=None, json=None, **kwargs):
+    def mock_post(url, headers=None, json=None, **kwargs):
         assert url.endswith("/rrsets/r1/actions/set_records")
         return DummyResp({"record": {"id": "r1"}})
 
     monkeypatch.setattr(backend_app.requests, "get", mock_get)
-    monkeypatch.setattr(backend_app.requests, "put", mock_put)
+    monkeypatch.setattr(backend_app.requests, "post", mock_post)
 
     client = backend_app.app.test_client()
     resp = client.post(


### PR DESCRIPTION
### Motivation
- The Hetzner Cloud Console API expects an action invocation to set RRSet records via a `POST` to `/zones/{zone}/rrsets/{id}/actions/set_records` rather than `PUT`, so the backend and docs must match the API.

### Description
- Replace `requests.put` with `requests.post` for the RRSet update call in `backend/app.py` when updating an existing record via `/zones/{zone}/rrsets/{id}/actions/set_records`.
- Update `tests/test_backend_update.py` to mock and assert `requests.post` for the update action instead of `requests.put`.
- Correct the README entry to document `POST /zones/{zone}/rrsets/{id}/actions/set_records` as the update action.

### Testing
- Ran `pytest -q` and all tests passed (`47 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698dd90e9dfc8321917e5a9702df6bae)